### PR TITLE
Make setting opts more versatile

### DIFF
--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -153,9 +153,6 @@ function M.reduce_hints_lines(per_line_hints, key)
 end
 
 function M.create_hints(hint_mode, buf_width, buf_height, cursor_pos, col_offset, lines, opts)
-  local keys = opts.keys
-  local reverse_distribution = opts.reverse_distribution
-
   -- extract all the words currently visible on screen; the hints variable contains the list
   -- of words as a pair of { line, column } for each word on a given line and indirect_words is a
   -- simple list containing { line, word_index, distance_to_cursor } that is sorted by distance to
@@ -173,7 +170,7 @@ function M.create_hints(hint_mode, buf_width, buf_height, cursor_pos, col_offset
   end
 
   local dist_comparison = nil
-  if reverse_distribution then
+  if opts.reverse_distribution then
     dist_comparison = function (a, b) return a.dist > b.dist end
   else
     dist_comparison = function (a, b) return a.dist < b.dist end
@@ -182,7 +179,7 @@ function M.create_hints(hint_mode, buf_width, buf_height, cursor_pos, col_offset
   table.sort(indirect_hints, dist_comparison)
 
   -- generate permutations and update the lines with hints
-  local perms = perm.permutations(keys, #indirect_hints, opts)
+  local perms = perm.permutations(opts.keys, #indirect_hints, opts)
   for i, indirect in pairs(indirect_hints) do
     hints[indirect.i].hints[indirect.j].hint = tbl_to_str(perms[i])
   end

--- a/lua/hop/perm.lua
+++ b/lua/hop/perm.lua
@@ -87,8 +87,7 @@ end
 -- Permutations are sorted by dimensions, so you will get 1-perm first, then 2-perm, 3-perm, etc. depending on the size
 -- of the keys.
 function M.permutations(keys, n, opts)
-  local term_seq_bias = opts and opts.term_seq_bias or defaults.term_seq_bias
-  local quarter = #keys * term_seq_bias
+  local quarter = #keys * opts.term_seq_bias
   local term_keys = keys:sub(1, quarter)
   local seq_keys = keys:sub(quarter + 1)
   local perms = {}


### PR DESCRIPTION
This PR implements consecutive opts lookup: *local command options* > *global set options* > *default options*
For example, in this case
```lua
require('hop').setup({winblend = 60, teasing = false})
vim.api.nvim_set_keymap('n', '<leader>w', "<cmd>lua require'hop'.hint_words({teasing = true})<cr>", {})
```
`hint_words` action will be executed with the following `opts`:
```lua
opts = {
  keys                 = 'asdghklqwertyuiopzxcvbnmfj', -- default
  reverse_distribution = false,                        -- default
  term_seq_bias        = 3 / 4,                        -- default
  winblend             = 60,                           -- global
  teasing              = true,                         -- local
}
```

This fixes the following issues:
- Not being able to set separate per-command options while falling back to already set global options. In the above example `winblend` will have `50` (default) value.
- You have to call `require('hop').setup({ ... })`, otherwise calling hop.nvim commands will result in errors.
-
  ```lua
  vim.api.nvim_set_keymap('n', '<leader>w', "<cmd>lua require'hop'.hint_words({})<cr>", {})
  ```
  throws an error because https://github.com/phaazon/hop.nvim/blob/master/lua/hop/keymap.lua#L13 tries to iterate over non-existent `keys` in the local opts table.