### PR TITLE
Escape special characters in char searches

### DIFF
--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -10,7 +10,10 @@ end
 -- Regex hint mode.
 --
 -- Used to hint result of a search.
-function M.by_searching(pat)
+function M.by_searching(pat, plain_search)
+  if plain_search then
+    pat = vim.fn.escape(pat, '\\/.$^~')
+  end
   return {
     match = function(s)
       return vim.regex(pat):match_str(s)

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -172,13 +172,13 @@ end
 
 function M.hint_char1(opts)
   local c = vim.fn.nr2char(vim.fn.getchar())
-  hint_with(hint.by_searching(c), get_command_opts(opts))
+  hint_with(hint.by_searching(c, true), get_command_opts(opts))
 end
 
 function M.hint_char2(opts)
   local a = vim.fn.nr2char(vim.fn.getchar())
   local b = vim.fn.nr2char(vim.fn.getchar())
-  hint_with(hint.by_searching(a .. b), get_command_opts(opts))
+  hint_with(hint.by_searching(a .. b, true), get_command_opts(opts))
 end
 
 function M.hint_lines(opts)


### PR DESCRIPTION
Fixes following madness:

Searching for `.` in `hint_char1(…)`

*before*
![2021-02-23_21-07](https://user-images.githubusercontent.com/35058624/108887950-ed28ca00-761b-11eb-883d-ddca48a6377f.png)

*after*
![image](https://user-images.githubusercontent.com/35058624/108888338-62949a80-761c-11eb-902b-f62c775f8467.png)