### PR TITLE
Reset highlighting after loading a new color scheme. #35

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,192 @@
+# Contributing
+
+This document is the official contribution guide contributors must follow. It will be **greatly appreciated** if you
+read it first before contributing. It will also prevent you from losing your time if you open an issue / make a PR that
+doesn’t comply to this document.
+
+<!-- vim-markdown-toc GFM -->
+
+* [Disclaimer and why this document](#disclaimer-and-why-this-document)
+* [How to make a change](#how-to-make-a-change)
+  * [Process](#process)
+* [Conventions](#conventions)
+  * [Coding](#coding)
+  * [Git](#git)
+    * [Git message](#git-message)
+    * [Commit atomicity](#commit-atomicity)
+    * [Hygiene](#hygiene)
+* [Release process](#release-process)
+  * [Overall process](#overall-process)
+  * [Changelogs update](#changelogs-update)
+  * [Git tag](#git-tag)
+* [Support and donation](#support-and-donation)
+
+<!-- vim-markdown-toc -->
+
+# Disclaimer and why this document
+
+People contributing is awesome. The more people contribute to Free & Open-Source software, the better the
+world is to me. However, the more people contribute, the more work we have to do on our spare-time. Good
+contributions are highly appreciated, especially if they thoroughly follow the conventions and guidelines of
+each and every repository. However, bad contributions — that don’t follow this document, for instance — are
+going to require me more work than was involved into making the actual change. It’s even worse when the contribution
+actually solves a bug or add a new feature.
+
+So please read this document; it’s not hard and the few rules here are easy to respect. You might already do
+everything in this list anyway, but reading it won’t hurt you. For more junior / less-experienced developers, it’s
+very likely you will learn a bit of process that is considered good practice, especially when working with VCS like
+Git.
+
+> Thank you!
+
+# How to make a change
+
+## Process
+
+The typical process is to base your work on the `master` branch. The `master` branch must always contain a stable
+version of the project. It is possible to make changes by basing your work on other branches but the source
+of truth is `master`. If you want to synchronize with other people on other branches, feel free to.
+
+The process is:
+
+1. (optional) Open an issue and discuss what you want to do. This is optional but highly recommended. If you
+  don’t open an issue first and work on something that is not in the scope of the project, or already being
+  made by someone else, you’ll be working for nothing. Also, keep in mind that if your change doesn’t refer to an
+  existing issue, I will be wondering what is the context of your change. So prepare to be asked about the motivation
+  and need behind your changes — it’s greatly appreciated if the commit messages, code and PR’s content already
+  contains this information so that people don’t have to ask.
+2. Fork the project.
+3. Create a branch starting from `master` – or the branch you need to work on. Even though this is not really enforced,
+  you’re advised to name your branch according to the _Git Flow_ naming convention:
+  - `fix/your-bug-here`: if you’re fixing a bug, name your branch.
+  - `feature/new-feature-here`: if you’re adding some work.
+  - Free for anything else.
+  - The special `release/*` branch is used to either back-port changes from newer versions to previous
+    versions, or to release new versions by updating files, changelogs, etc. Normally, contributors should
+    never have to worry about this kind of brach as their creations is often triggered when wanting to make a release.
+4. Make some commits!
+5. Once you’re ready, open a Pull Request (PR) to merge your work on the target branch. For instance, open a PR for
+  `master <- feature/something-new`.
+6. (optional) Ask someone to review your code in the UI. Normally, I’m pretty reactive to notifications but it never
+  hurts to ask for a review.
+7. Discussion and peer-review.
+8. Once the CI is all green, someone (likely me [@phaazon]) will merge your code and close your PR.
+9. Feel free to delete your branch.
+
+# Conventions
+
+## Coding
+
+N/A
+
+## Git
+
+### Git message
+
+Please format your git messages like so:
+
+> Starting with an uppercase letter, ending with a dot. #343
+>
+> The #343 after the dot is appreciated to link to issues. Feel free to add, like this message, more context
+> and/or precision to your git message. You don’t have to put it in the first line of the commit message,
+> but if you are fixing a bug or implementing a feature thas has an issue linked, please reference it, so
+> that it is easier to generate changelogs when reading the git log.
+
+**I’m very strict on git messages as I use them to write `CHANGELOG.md` files. Don’t be surprised if I ask you
+to edit a commit message. :)**
+
+### Commit atomicity
+
+Your commits should be as atomic as possible. That means that if you make a change that touches two different
+concepts / has different scopes, most of the time, you want two commits – for instance one commit for the backend code
+and one commit for the interface code. There are exceptions, so this is not an absolute rule, but take some time
+thinking about whether you should split your commits or not. Commits which add a feature / fix a bug _and_ add tests at
+the same time are fine.
+
+However, here’s a non-comprehensive list of commits considered bad and that will be refused:
+
+- **Formatting, refactoring, cleaning, linting code in a PR that is not strictly about formatting**. If you open a PR to
+  fix a bug, implement a  feature, change configuration, add metadata to the CI, etc. — pretty much anything — but you
+  also format some old code that has nothing to do with your PR, apply a linter’s suggestions (such as `clippy`), remove
+  old code, etc., then I will refuse your commit(s) and ask you to edit your PR.
+- **Too atomic commits**. If two commits are logically connected to one another and are small, it’s likely that you want
+  to merge them as a single commit — unless they work on too different parts of your code. This is a bit subjective
+  topic, so I won’t be _too picky_ about it, but if I judge that you should split a commit into two or fixup two commits,
+  please don’t take it too personal. :)
+
+If you don’t know how to write your commits in an atomic maneer, think about how one would revert your commits if
+something bad happens with your changes — like a big breaking change we need to roll back from very quickly. If your
+commits are not atomic enough, rolling them back will also roll back code that has nothing to do with your changes.
+
+### Hygiene
+
+When working on a fix or a feature, it’s very likely that you will periodically need to update your branch
+with the `master` branch. **Do not use merge commits**, as your contributions will be refused if you have
+merge commits in them. The only case where merge commits are accepted is when you work with someone else
+and are required to merge another branch into your feature branch (and even then, it is even advised to
+simply rebase). If you want to synchronize your branch with `master`, please use:
+
+```
+git switch <your_branch>
+git fetch origin --prune
+git rebase origin/master
+```
+
+# Release process
+
+## Overall process
+
+Releases occur at arbitrary rates. If something is considered urgent, it is most of the time released immediately
+after being merged and tested. Sometimes, several issues are being fixed at the same time (spanning on a few
+days at max). Those will be gathered inside a single update.
+
+Feature requests might be delayed a bit to be packed together as well but eventually get released, even if
+they’re small. Getting your PR merged means it will be released _soon_, but depending on the urgency of your changes,
+it might take a few minutes to a few days.
+
+## Changelogs update
+
+`CHANGELOG.md` files must be updated **before any release**. Especially, they must contain:
+
+- The version of the release.
+- The date of the release.
+- How to migrate from a minor to the next major.
+- Everything that a release has introduced, such as major, minor and patch changes.
+
+Because I don’t ask people to maintain changelogs, I have a high esteem of people knowing how to use Git and create
+correct commits. Be advised that I will refuse any commit that prevents me from writing the changelog correctly.
+
+## Git tag
+
+Once a new release occurs, a Git tag is created. Git tags are formatted regarding the project they refer to, if several
+projects are present in the repository. If only one project is present, tags will refer to this project by the same
+naming scheme anyway:
+
+> <project-name>-X.Y.Z
+
+Where `X` is the _major version_, `Y` is the _minor version_ and `Z` is the _patch version_. For instance
+`project-0.37.1` is a valid Git tag, so is `project-derive-0.5.3`.
+
+A special kind of tag is also possible:
+
+> <project-name>-X.Y.Z-rc.W
+
+Where `W` is a number starting from `1` and incrementing. This format is for _release candidates_ and occurs
+when a new version (most of the time a major one) is to be released but more feedback is required.
+
+# Support and donation
+
+This project is a _free  and  open-source_ project. It has no financial motivation nor support. I
+([@phaazon]) would like to make it very clear that:
+
+- Sponsorship is not available. You cannot pay me to make me do things for you. That includes issues reports,
+  features requests and such.
+- If you still want to donate because you like the project and think I should be rewarded, you are free to
+  give whatever you want.
+- However, keep in mind that donating doesn’t unlock any privilege people who don’t donate wouldn’t already
+  have. This is very important as it would bias priorities. Donations must remain anonymous.
+- For this reason, no _sponsor badge_ will be shown, as it would distinguish people who donate from those
+  who don’t. This is a _free and open-source_ project, everybody is welcome to contribute, with or without
+  money.
+
+[@phaazon]: https://github.com/phaazon

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2021, Dimitri Sabadie <dimitri.sabadie@gmail.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Dimitri Sabadie <dimitri.sabadie@gmail.com> nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,222 @@
+                                              __
+                                             / /_  ____  ____
+                                            / __ \/ __ \/ __ \
+                                           / / / / /_/ / /_/ /
+                                          /_/ /_/\____/ .___/
+                                                     /_/
+                                      · Neovim motions on speed! ·
+
+**Hop** is an [EasyMotion]-like plugin allowing you to jump anywhere in a
+document with as few keystrokes as possible. It does so by annotating text in
+your buffer with hints, short string sequences for which each character
+represents a key to type to jump to the annotated text. Most of the time,
+those sequences’ lengths will be between 1 to 3 characters, making every jump
+target in your document reachable in a few keystrokes.
+
+**Hop** is a complete from-scratch rewrite of [EasyMotion], a famous plugin to
+enhance the native motions of Vim. Even though [EasyMotion] is usable in
+Neovim, it suffers from a few drawbacks making it not comfortable to use with
+Neovim version >0.5 – at least at the time of writing these lines:
+
+- [EasyMotion] uses an old trick to annotate jump targets by saving the
+  contents of the buffer, replacing it with the highlighted annotations and
+  then restoring the initial buffer after jump. This trick is dangerous as it
+  will change the contents of your buffer. A UI plugin should never do anything
+  to existing buffers’ contents.
+- Because the contents of buffers will temporarily change, other parts of the
+  editor and/or plugins relying on buffer change events will react and will go
+  mad. An example is the internal LSP client implementation of Neovim >0.5 or
+  its treesitter native implementation. For LSP, it means that the connected
+  LSP server will receive a buffer with the jump target annotations… not
+  ideal.
+
+**Hop** is a modern take implementing this concept for the latest versions of
+Neovim.
+
+<!-- vim-markdown-toc GFM -->
+
+* [Features](#features)
+  * [Word mode (`:HopWord`)](#word-mode-hopword)
+  * [Line mode (`:HopLine`)](#line-mode-hopline)
+  * [1-char mode (`:HopChar1`)](#1-char-mode-hopchar1)
+  * [2-char mode (`:HopChar2`)](#2-char-mode-hopchar2)
+  * [Pattern mode (`:HopPattern`)](#pattern-mode-hoppattern)
+  * [Visual extend](#visual-extend)
+  * [Jump on sole occurrence](#jump-on-sole-occurrence)
+* [Getting started](#getting-started)
+  * [Disclaimer and experimental notice](#disclaimer-and-experimental-notice)
+  * [Installation](#installation)
+    * [Special notes regarding extended marks and virtual text](#special-notes-regarding-extended-marks-and-virtual-text)
+* [Usage](#usage)
+* [Keybindings](#keybindings)
+* [Configuration](#configuration)
+
+<!-- vim-markdown-toc -->
+
+# Features
+
+- [x] Go to any word in the current buffer.
+- [x] Go to any character in the current buffer.
+- [x] Go to any bigrams in the current buffer.
+- [x] Make an arbitrary search akin to <kbd>/</kbd> and go to any occurrences.
+- [x] Go to any line.
+- [x] Visual extend mode, which allows you to extend a visual selection by hopping elsewhere in the document.
+
+## Word mode (`:HopWord`)
+
+This mode highlights all the recognized words in the visible part of the buffer and allows you to jump to any.
+
+![](https://phaazon.net/media/uploads/hop_word_mode.gif)
+
+## Line mode (`:HopLine`)
+
+This mode highlights the beginnings of each line in the visible part of the buffer for quick line hopping.
+
+![](https://phaazon.net/media/uploads/hop_line_mode.gif)
+
+## 1-char mode (`:HopChar1`)
+
+This mode expects the user to type a single character. That character will then be highlighted in the visible part of
+the buffer, allowing to jump to any of its occurrence. This mode is especially useful to jump to operators, punctuations
+or any symbols not recognized as parts of words.
+
+![](https://phaazon.net/media/uploads/hop_char1_mode.gif)
+
+## 2-char mode (`:HopChar2`)
+
+A variant of the 1-char mode, this mode exacts the user to type two characters, representing a _bigram_ (they follow
+each other, in order). The bigram occurrences in the visible part of the buffer will then be highlighted for you to jump
+to any.
+
+![](https://phaazon.net/media/uploads/hop_char2_mode.gif)
+
+## Pattern mode (`:HopPattern`)
+
+Akin to `/`, this mode prompts you for a pattern (regex) to search. Occurrences will be highlighted, allowing you to
+jump to any.
+
+![](https://phaazon.net/media/uploads/hop_pattern_mode.gif)
+
+## Visual extend
+
+If you call any Hop commands / Lua functions from one of the visual modes, the visual selection will be extended.
+
+![](https://phaazon.net/media/uploads/hop_visual_extend.gif)
+
+## Jump on sole occurrence
+
+If only a single occurrence is visible in the buffer, Hop will automatically jump to it without requiring pressing any
+extra key.
+
+![](https://phaazon.net/media/uploads/hop_sole_occurrence.gif)
+
+# Getting started
+
+This section will guide you through the list of steps you must take to be able to get started with **Hop**.
+
+This plugin was written against Neovim 0.5, which is currently a nightly version. However, Neovim 0.4 should work
+too. If you are still on Neovim 0.4, feel free to reach out and tell me how is your experience going.
+
+This plugin will not currently work on Vim and no support for Vim is planned.
+
+## Disclaimer and experimental notice
+
+**Please read this section before going on any further.**
+
+The plugin was born from scratch on 5th February of 2021 and, at the time of writing this, is two days old. Even though
+it has reached a usable state, it still has some remaining issues to fix. You can get the full list of them with the
+embedded help, if you are curious:
+
+```vim
+:help hop-limitations-issues
+```
+
+If you are encountering any of these issues, **you do not have to open an issue as it is already being actively worked
+on.** However, PRs are greatly appreciated.
+
+## Installation
+
+Using [vim-plug]:
+
+```vim
+Plug 'phaazon/hop.nvim'
+```
+
+### Special notes regarding extended marks and virtual text
+
+Extended marks and virtual text is a very recent addition to Neovim-0.5. The feature is still experimental but so far no
+bug related to them were found in Hop. However, if you would rather stick to the legacy implementation, you are advised
+to pinpoint the `pre-extmarks` branch. For instance, with [vim-plug]:
+
+```vim
+Plug 'phaazon/hop.nvim', { 'branch': 'pre-extmarks' }
+```
+
+Keep in mind that this branch is provided as-is until Neovim bugs are fixed regarding extended marks (if any). I don’t
+plan on maintaining this branch and it should be short-living.
+
+# Usage
+
+A bunch of vim commands are available to get your fingers wrapped around **Hop** quickly:
+
+- `:HopWord`: hop around by highlighting words.
+- `:HopPattern`: hop around by matching against a pattern (as with `/`).
+- `:HopChar1`: type a single key and hop to any occurrence of that key in the document.
+- `:HopChar2`: type a bigram (two keys) and hop to any occurrence of that bigram in the document.
+- `:HopLine`: jump to any visible line in your buffer.
+
+If you would rather use the Lua API, you can test it via the command prompt:
+
+```vim
+:lua require'hop'.hint_words()
+```
+
+If you want to create a key binding (<kbd>$</kbd> in this example) from within Lua:
+
+```lua
+-- place this in one of your configuration file(s)
+vim.api.nvim_set_keymap('n', '$', "<cmd>lua require'hop'.hint_words()<cr>", {})
+```
+
+For a more complete user guide and help pages:
+
+```vim
+:help hop
+```
+
+# Keybindings
+
+Hop doesn’t set any keybindings; you will have to define them by yourself.
+
+However, once Hop is started in any mode, it will override your buffer-local keybindings, if any (so that you can jump
+around). After a jump or quitting Hop, your keybindings are restored.
+
+> Note: if you find any issue with the buffer-local keymaps, please open an issue.
+
+# Configuration
+
+You can configure Hop via several different mechanisms:
+
+- _Global configuration_ uses the Lua `setup` API (`:h hop.setup`). This allows you to setup global options that will be
+  used by all Hop Lua functions as well as the vim commands (e.g. `:HopWord`). This is the easiest way to configure Hop
+  on a global scale. You can do this in your `init.lua` or any `.vim` file by using the `lua` vim command.
+  Example:
+  ```vim
+  " init.vim
+  "
+  " Use better keys for the bépo keyboard layout and set
+  " a balanced distribution of terminal / sequence keys
+  lua require'hop'.setup { keys = 'etovxqpdygfblzhckisuran', term_seq_bias = 0.5 }
+  ```
+- _Local configuration overrides_ are available only on the Lua API and are `{opts}` Lua tables passed to the various
+  Lua functions. Those options have precedence over global options, so they allow to locally override options. Useful if
+  you want to test a special option for a single Lua function, such as `require'hop'.hint_lines()`. You can test them
+  inside the command line, such as:
+  ```
+  :lua require'hop'.hint_words({ term_seq_bias = 0.5 })
+  ```
+- In the case of none of the above are provided, options are automatically read from the _default_ options. See `:h
+  hop-config` for a list of default values.
+
+[EasyMotion]: https://github.com/easymotion/vim-easymotion
+[vim-plug]: https://github.com/junegunn/vim-plug

--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -1,0 +1,444 @@
+*hop.txt*    For Neovim version 0.5                  Last change: 2021 Feb 6
+
+                                 __
+                                / /_  ____  ____
+                               / __ \/ __ \/ __ \
+                              / / / / /_/ / /_/ /
+                             /_/ /_/\____/ .___/
+                                        /_/
+                         · Neovim motions on speed! ·
+
+==============================================================================
+CONTENTS                                                          *hop-contents*
+
+  Introduction ·············································· |hop-introduction|
+  Requirements ·············································· |hop-requirements|
+  Limitations and known issues ························ |hop-limitations-issues|
+  Usage ···························································· |hop-usage|
+    Commands ···················································· |hop-commands|
+    Lua API ······················································ |hop-lua-api|
+  Configuration ··················································· |hop-config|
+  Highlights ·················································· |hop-highlights|
+  License ························································ |hop-license|
+
+==============================================================================
+INTRODUCTION                                              *hop* *hop-introduction*
+
+Hop is an “EasyMotion” like plugin allowing you to jump anywhere in a document
+with as few keystrokes as possible. It does so by annotating text in your
+buffer with |hints|, short string sequences for which each character represents
+a key to type to jump to the annotated text. Most of the time, those
+sequences’ lengths will be between 1 to 3 characters, making every jump target
+in your document reachable in a few keystrokes.
+
+Hop is a complete from-scratch rewrite of EasyMotion, a famous plugin to
+enhance the native motions of Vim. Even though EasyMotion is usable in
+Neovim, it suffers from a few drawbacks making it not comfortable to use with
+Neovim version >0.5 – at least at the time of writing these lines:
+
+- EasyMotion uses an old trick to annotate jump targets by saving the
+  contents of the buffer, replacing it with the highlighted annotations and
+  then restoring the initial buffer after jump. This trick is dangerous as it
+  will change the contents of your buffer. A UI plugin should never do anything
+  to existing buffers’ contents.
+- Because the contents of buffers will temporarily change, other parts of the
+  editor and/or plugins relying on buffer change events will react and will go
+  mad. An example is the internal LSP client implementation of Neovim >0.5 or
+  its treesitter native implementation. For LSP, it means that the connected
+  LSP server will receive a buffer with the jump target annotations… not
+  ideal.
+
+==============================================================================
+REQUIREMENTS                                                  *hop-requirements*
+
+Hop works only with Neovim and was written with Neovim-0.5, so it is highly
+recommended to use Neovim version 0.5+.
+
+Especially, hop uses |api-extended-marks|, which are not available before
+Neovim-0.5.
+
+==============================================================================
+LIMITATIONS AND KNOWN ISSUES                            *hop-limitations-issues*
+
+Folds are currently not supported, so they will break Hop pretty badly.
+
+==============================================================================
+USAGE                                                                *hop-usage*
+
+                                                                  *hop-commands*
+Commands~
+
+You can try those commands by typing them in your command line. By default,
+they will use the default options for the configuration of Hop. If you want to
+customize how those functions work, have a look at |hop.setup|.
+
+`:HopWord`                                                              *:HopWord*
+    Annotate all words in the current window with key sequences. Typing a
+    first  key will visually filter the sequences and reduce them. Continue
+    typing key sequences until you reduce a sequence completely, which will
+    bring your cursor at that position.
+
+    This is akin to calling the |hop.hint_words| Lua function.
+
+`:HopPattern`                                                        *:HopPattern*
+    Ask the user for a pattern and hint the document with it.
+
+    This is akin to calling the |hop.hint_patterns| Lua function.
+
+`:HopChar1`                                                            *:HopChar1*
+    Type a key and immediately hint the document for this key.
+
+    This is akin to calling the |hop.hint_char1| Lua Function
+
+`:HopChar2`                                                            *:HopChar2*
+    Type two keys and immediately hint the document for this bigram.
+
+    This is akin to calling the |hop.hint_char2| Lua Function
+
+`:HopLine`                                                              *:HopLine*
+    Jump to the beginning of the line of your choice inside your buffer.
+
+    This is akin to calling the |hop.hint_lines| Lua function.
+
+                                                                   *hop-lua-api*
+Lua API~
+
+The Lua API comprises several modules:
+
+`hop`           Entry point and main interface. If you just want to use
+              Hop from within Lua via keybindings, you shouldn’t need to
+              read any other modules.
+`hop.defaults`  Default options.
+`hop.hint`      Various functions to create, update and reduce hints.
+`hop.keymap`    Implementation of the keymap allowing to perform jumps.
+`hop.perm`      Permutation functions. Permutations are used as labels for
+              the hints.
+
+Main API~
+
+Most of the functions and values you need to know about are in `hop`.
+
+`hop.setup(`{opts}`)`                                                    *hop.setup*
+    Setup the library with options.
+
+    This functional will setup the Lua API and commands in a way that respects
+    the options you pass.
+
+    The list of available options is available in the |hop-config| section.
+
+`hop.hint_words(`{opts}`)`                                          *hop.hint_words*
+    Annotate all words in the current window with key sequences. Typing a
+    first key will visually filter the sequences and reduce them. Continue
+    typing key sequences until you reduce a sequence completely, which will
+    bring your cursor at that position. See |hop-config| for a complete list
+    of the options you can pass as arguments.
+
+`hop.hint_patterns(`{opts}`)`                                    *hop.hint_patterns*
+    Annotate all patterns in the current window with key sequences after
+    having prompted the user for the pattern to search.
+
+`hop.hint_char1(`{opts}`)`                                          *hop.hint_char1*
+    Let the user type a key and immediately hint all of its occurrences.
+
+`hop.hint_char2(`{opts}`)`                                          *hop.hint_char2*
+    Let the user type a bigram (two concatenated keys) and immediately hint
+    all of its occurrences.
+
+`hop.hint_lines(`{opts}`)`                                          *hop.hint_lines*
+    Hint the beginning of each lines currently visible in the buffer view and
+    allow to jump to them.
+
+    This works with empty lines as well.
+
+`hop.refine_hints(`{buf_handle}`,` {key}`)`                         *hop.refine_hints*
+    Refine hints in buffer {buf_handle} by reducing sequences starting with
+    {key}. If a sequence has only one key remaining and that key is {key},
+    the associated hint jump target is triggered.
+
+    If {key} is not found as the first key in any sequence currently visible,
+    the function will abort and report an error to the user stating that no
+    remaining sequence starts with {key}.
+
+Hint API~
+
+The hint API allows to create, reduce and display *hints* in easy ways.
+
+`hop.hint.by_word_start`                                  *hop.hint.by_word_start*
+    |word| hint mode. This mode will highlights the beginnings of all the
+    words in the document and will make the cursor jump to the one fully
+    reduced.
+
+`hop.hint.by_searching(`{pat}`)`                             *hop.hint.by_searching*
+    |pattern| hint mode. This mode will highlights the beginnings of a pattern
+    you will be prompted for in the document and will make the cursor jump to
+    the one fully reduced.
+
+`hop.hint.mark_hints_line(`                             *hop.hint.mark_hints_line*
+  {hint_mode}`,`
+  {line_nr}`,`
+  {line}
+`)`
+    Mark the given {line} with hints according to the input {hint_mode}. The
+    {line_nr} must be the row where the {line} comes from.
+
+    This function returns all the hints for {line} as a table consisting of
+    three information gathered under two keys:
+>
+        {
+          hints = { line, col, real_col };
+          length
+        }
+<
+    `line` is the same as {line_nr} and is simply forwarded. `col` is the
+    column at which the hint visually starts. `real_col` is the column at
+    which the hint starts taking into account multi-byte characters.
+
+    Use `col` for displaying the hints and `real_col` to jump to it.
+
+    `length` is the length of the initial hinted line. This is an important
+    information used to correctly implement 'wrap' and 'nowrap' support.
+
+    The returned hint is to be considered as a placeholder, as it doesn’t have
+    its hint label yet. Have a look at |hop.hint.create_hints| for further
+    information about how the `hint` field is added.
+
+`hop.hint.reduce_hint(`{hint}`,` {key}`)`                       *hop.hint.reduce_hint*
+    Reduce {hint} with {key}.
+
+    If {hint} didn’t start with {key}, it is returned as-is. If {hint} started
+    with {key}, that {key} is removed from its beginning. If the remaining
+    hint is empty, `nil` is returned, otherwise the reduction is returned.
+
+`hop.hint.reduce_hints_lines(`                       *hop.hint.reduce_hints_lines*
+  {per_line_hints}`,`
+  {key}
+`)`
+    Reduce all hints in {per_line_hints} and return the fully reduced one, if
+    any.
+
+    If a hint is fully reduced, its `hint` field will be `nil` but its `line`,
+    `col` and `real_col` fields can still be used to jump to it.
+
+`hop.hint.create_hints(`                                   *hop.hint.create_hints*
+  {hint_mode}`,`
+  {buf_heigth}`,`
+  {cursor_pos}`,`
+  {lines}`,`
+  {opts}
+`)`
+    Given a set of {lines}, this function creates the hints for each line in
+    {lines} by respecting the {hint_mode}. The {cursor_pos} is used to alter
+    the sequence distribution over the buffer.
+
+    The returned value is a table containing the following fields:
+>
+        { line, col, real_col, hint }
+<
+    The meaning of `line`, `col` and `real_col` is the same as with
+    |hop.hint.mark_hints_line|. `hint` contains the permutation making the
+    sequence that can be displayed and typed by a user to jump to.
+
+`hop.hint.create_buffer_lines(`                     *hop.hint.create_buffer_lines*
+  {buf_width}`,`
+  {buf_height}`,`
+  {per_line_hints}
+`)`
+    Create the lines that can be put in a buffer to show the hints. The lines
+    are created by using an algorithm allowing the hints to be cut if they
+    overlap with others. {per_line_hints} should be an object returned by
+    |hop.hint_create_hints|.
+
+    This function returns the content of the buffer as a list of lines, and
+    each line is represented with a single string.
+
+Permutation API~
+
+The permutation API is the core part of the algorithm used in Hop.
+Permutations in Hop are made out of a source sequence of characters, called
+a key set and represented with {keys}. A good choice of key set is important
+to yield short and concise permutations, allowing to jump to targets with
+fewer keystrokes.
+
+`hop.perm.permutations(`{keys}`,` {n}`,` {opts}`)`               *hop.perm.permutations*
+    Get the first {n} permutations out of {keys}.
+
+    This function will generate shorter permutations first, and when a given
+    dimension is fully exhausted, will switch to the next dimension. The first
+    permutations will be of dimension 1 (i.e. a single character), taken out
+    from {keys}. Once all keys are exhausted for 1-character permutations, the
+    next permutations will be generated for dimension 2 (i.e. two characters),
+    also taken out from {keys}, then dimension 3, etc. etc.
+
+    {keys} is split into two sets: terminal keys are keys that, when pressed,
+    immediately trigger a jump. They can be found in the 1-character
+    permutations and at the end of longer sequences, but never at the
+    beginning nor the middle of longer permutations. Sequence keys represent
+    the second set and can never be found in 1-character permutations, nor in
+    terminal positions of longer ones.
+
+    For a permutation `perm` which length is greater or equal than 2, any keys
+    for which the index in the permutation is between `1` and `#perm - 1` are
+    sequence keys and the last key in the permutation at index `#perm` is a
+    terminal key.
+
+Keymap API~
+
+The keymap API allows to create buffer-local bindings to be able to jump to
+hints targets. Those keymaps are automatically inserted when you call
+functions such as |hop.jump_words|. They are made out of the {keys} in your
+{opts}.
+
+`hop.keymap.create_jump_keymap(`                   *hop.keymap.create_jump_keymap*
+  {buf_handle}`,`
+  {opts}
+`)`
+    Create the dynamic keymap in the buffer referred to by {buf_handle} by
+    mapping all the keys found in {opts}.{keys}.
+
+    If {opts} is `nil` or if {opts}.{keys} is `nil`, the appropriate {keys}
+    value will be taken out from the default value — see |hop-config|.
+
+==============================================================================
+CONFIGURATION                                                       *hop-config*
+
+The configuration can be provided in two different ways:
+
+- Either by explicitly passing an {opts} table to the various Lua
+  functions.
+- Or by passing an {opts} table to the Lua |hop.setup| function.
+
+Not providing any of the two above will use the _default values_, as described
+below.
+
+`keys`                                                           *hop-config-keys*
+    A string representing all the keys that can be part of a permutation.
+    Every character (key) used in the string will be used as part of a
+    permutation. The shortest permutation is a permutation of a single
+    character, and, depending on the content of your buffer, you might end up
+    with 3-character (or more) permutations in worst situations.
+
+    However, it is important to notice that if you decide to provide `keys`,
+    you have to ensure to use enough characters in the string, otherwise you
+    might get very long sequences and a not so pleasant experience.
+
+    Another important aspect is that the order of the characters you put in
+    your `keys` is important. Depending on the value you use in
+    |hop-config-term_seq_bias|, the keys will be split in two and the first
+    part of it will be used for terminal keys and the second part for sequence
+    keys.
+
+    Defaults:
+>
+        keys = 'asdghklqwertyuiopzxcvbnmfj'
+<
+`reverse_distribution`                           *hop-config-reverse_distribution*
+    The default behavior for key sequence distribution in your buffer is to
+    concentrate shorter sequences near the cursor, grouping 1-character
+    sequences around. As words get further from the cursor, the dimension of
+    the sequences will grow, making the furthest words the longest sequences
+    to type.
+
+    Set this option to `true` to reverse the density and concentrate the
+    shortest sequences (1-character) around the furthest words and the longest
+    sequences around the cursor.
+
+    Defaults:
+>
+        reverse_distribution = false
+<
+`term_seq_bias`                                         *hop-config-term_seq_bias*
+    Bias used to alter the proportion of keys used as terminal keys vs. used
+    as sequence keys. It is not recommended to tweak around with this value
+    too much as it will degrade the experience, but if you really want to give
+    it a try, you should set this value to a number representing the ratio of
+    terminal keys and sequence keys. A ratio of `3/4`, for instance, means
+    that for 12 keys, 9 will be used as terminal keys and 3 will be used as
+    sequence keys.
+
+    Defaults:
+>
+        term_seq_bias = 3 / 4
+<
+`winblend`                                                   *hop-config-winblend*
+    'winblend' value to use for the hint buffer.
+
+    Remember that setting a fully opaque hint buffer will make it impossible
+    to see where you are jumping.
+
+    Defaults:
+>
+        winblend = 50
+<
+`teasing`                                                     *hop-config-teasing*
+    Boolean value stating whether Hop should tease you when you do something
+    you are not supposed to.
+
+    If you find this setting annoying, feel free to turn it to `false`.
+
+    Defaults:
+>
+        teasing = true
+<
+
+`jump_on_sole_occurrence`                     *hop-config-jump_on_sole_occurrence*
+    Immediately jump without displaying hints if only one occurrence exists.
+
+    Defaults:
+>
+        jump_on_sole_occurrence = true
+<
+==============================================================================
+LICENSE                                                            *hop-license*
+
+Copyright (c) 2021, Dimitri Sabadie <dimitri.sabadie@gmail.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Dimitri Sabadie <dimitri.sabadie@gmail.com> nor the
+      names of other contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+==============================================================================
+HIGHLIGHTS                                                      *hop-highlights*
+
+Anywhere in the hint buffer that doesn’t contain a hint, the |hl-EndOfBuffer|
+highlight is used. For the rest:
+
+`HopNextKey`                                                   *hop-hl-HopNextkey*
+    Highlight used for the mono-sequence keys (i.e. sequence of 1).
+
+`HopNextKey1`                                                 *hop-hl-HopNextKey1*
+    Highlight used for the first key in a sequence.
+
+`HopNextKey2`                                                 *hop-hl-HopNextKey2*
+    Highlight used for the second and remaining keys in a sequence.
+
+`HopUnmatched`                                               *hop-hl-HopUnmatched*
+    Highlight used for unmatched part of the buffer when running a Hop command
+    / Lua functions.
+
+==============================================================================
+vim:tw=78:sw=4:ts=8:ft=help:norl:

--- a/lua/hop/defaults.lua
+++ b/lua/hop/defaults.lua
@@ -1,0 +1,10 @@
+local M = {}
+
+M.keys = 'asdghklqwertyuiopzxcvbnmfj'
+M.reverse_distribution = false
+M.term_seq_bias = 3 / 4
+M.winblend = 50
+M.teasing = true
+M.jump_on_sole_occurrence = true
+
+return M

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -1,0 +1,208 @@
+local perm = require'hop.perm'
+
+local M = {}
+
+-- Small utility functions for alignments / filling.
+local function next_mul(x, m)
+  return x + m - x % m
+end
+
+-- Regex hint mode.
+--
+-- Used to hint result of a search.
+function M.by_searching(pat, plain_search)
+  if plain_search then
+    pat = vim.fn.escape(pat, '\\/.$^~[]')
+  end
+  return {
+    match = function(s)
+      return vim.regex(pat):match_str(s)
+    end
+  }
+end
+
+-- Word hint mode.
+--
+-- Used to tag words with hints.
+-- M.by_word_start = M.by_searching('\\<\\w\\+')
+M.by_word_start = M.by_searching('\\w\\+')
+
+-- Line hint mode.
+--
+-- Used to tag the beginning of each lines with ihnts.
+M.by_line_start = {
+  match = function(s)
+    local len = vim.fn.strdisplaywidth(s)
+
+    if len == 0 then
+      return nil
+    else
+      return 0, len
+    end
+  end
+}
+
+-- Turn a table representing a hint into a string.
+local function tbl_to_str(hint)
+  local s = ''
+
+  for i = 1, #hint do
+    s = s .. hint[i]
+  end
+
+  return s
+end
+
+-- Manhattan distance with column and row, weighted on x so that results are more packed on y.
+local function manh_dist(a, b, x_bias)
+  local bias = x_bias or 10
+  return bias * math.abs(b[1] - a[1]) + math.abs(b[2] - a[2])
+end
+
+-- Mark the current line with hints for the given hint mode.
+--
+-- This function applies reg repeatedly until it fails (typically at the end of
+-- the line). For every match of the regex, a hint placeholder is generated, which
+-- contains three fields giving the line, hint column and real column of the hint:
+--
+--   { line, col }
+--
+-- The input line_nr is the line number of the line currently being marked.
+--
+-- This function returns the list of hints as well as the length of the line in the form of table:
+--
+--   { hints, length }
+function M.mark_hints_line(hint_mode, line_nr, line, col_offset, win_width)
+  local hints = {}
+  local end_index = nil
+
+  if win_width ~= nil then
+    end_index = col_offset + win_width
+  else
+    end_index = vim.fn.strdisplaywidth(line)
+  end
+
+  local shifted_line = line:sub(1 + col_offset, end_index)
+
+  -- prevent empty lines from being really empty; useful for some modes
+  if #shifted_line == 0 then
+    shifted_line = ' '
+  end
+
+  local col = 1
+  while true do
+    local s = shifted_line:sub(col)
+    local b, e = hint_mode.match(s)
+
+    if b == nil then
+      break
+    end
+
+    local colb = col + b
+    hints[#hints + 1] = {
+      line = line_nr;
+      col = colb + col_offset;
+    }
+
+    col = col + e
+  end
+
+  return {
+    hints = hints;
+    length = vim.fn.strdisplaywidth(shifted_line)
+  }
+end
+
+-- Reduce a hint.
+--
+-- This function will remove hints not starting with the input key and will reduce the other ones
+-- with one level.
+function M.reduce_hint(hint, key)
+  if hint:sub(1, 1) == key then
+    hint = hint:sub(2)
+  end
+
+  if hint == '' then
+    hint = nil
+  end
+
+  return hint
+end
+
+-- Reduce all hints and return the one fully reduced, if any.
+function M.reduce_hints_lines(per_line_hints, key)
+  local output = {}
+  local update_count = 0
+
+  for _, hints in pairs(per_line_hints) do
+    local next_hints = {}
+
+    for _, h in pairs(hints.hints) do
+      local prev_hint = h.hint
+      h.hint = M.reduce_hint(h.hint, key)
+
+      if h.hint == nil then
+        return h
+      elseif h.hint ~= prev_hint then
+        next_hints[#next_hints + 1] = h
+        update_count = update_count + 1
+      end
+    end
+
+    output[#output + 1] = { hints = next_hints; length = hints.length }
+  end
+
+  return nil, output, update_count
+end
+
+function M.create_hints(hint_mode, win_width, lines_count, cursor_pos, col_offset, top_line, lines, opts)
+  -- extract all the words currently visible on screen; the hints variable contains the list
+  -- of words as a pair of { line, column } for each word on a given line and indirect_words is a
+  -- simple list containing { line, word_index, distance_to_cursor } that is sorted by distance to
+  -- cursor, allowing to zip this list with the hints and distribute the hints
+  local hints = {}
+  local indirect_hints = {}
+  local hint_counts = 0
+  for i = 1, lines_count do
+    local line_hints = M.mark_hints_line(hint_mode, top_line + i - 1, lines[i], col_offset, win_width)
+    hints[i] = line_hints
+
+    hint_counts = hint_counts + #line_hints.hints
+
+    for j = 1, #line_hints.hints do
+      local hint = line_hints.hints[j]
+      indirect_hints[#indirect_hints + 1] = { i = i; j = j; dist = manh_dist(cursor_pos, { hint.line, hint.col }) }
+    end
+  end
+
+  local dist_comparison = nil
+  if opts.reverse_distribution then
+    dist_comparison = function (a, b) return a.dist > b.dist end
+  else
+    dist_comparison = function (a, b) return a.dist < b.dist end
+  end
+
+  table.sort(indirect_hints, dist_comparison)
+
+  -- generate permutations and update the lines with hints
+  local perms = perm.permutations(opts.keys, #indirect_hints, opts)
+  for i, indirect in pairs(indirect_hints) do
+    hints[indirect.i].hints[indirect.j].hint = tbl_to_str(perms[i])
+  end
+
+  return hints,  hint_counts
+end
+
+function M.set_hint_extmarks(hl_ns, per_line_hints)
+  for _, hints in pairs(per_line_hints) do
+    for _, hint in pairs(hints.hints) do
+      if #hint.hint == 1 then
+        vim.api.nvim_buf_set_extmark(0, hl_ns, hint.line, hint.col - 1, { virt_text = { { hint.hint, "HopNextKey"} }; virt_text_pos = 'overlay' })
+      else
+        vim.api.nvim_buf_set_extmark(0, hl_ns, hint.line, hint.col - 1, { virt_text = { { hint.hint:sub(1, 1), "HopNextKey1"}, { hint.hint:sub(2), "HopNextKey2" } }; virt_text_pos = 'overlay' })
+      end
+    end
+  end
+end
+
+return M

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -1,0 +1,194 @@
+local defaults = require'hop.defaults'
+local hint = require'hop.hint'
+local keymap = require'hop.keymap'
+
+local M = {}
+
+M.opts = defaults
+
+-- Setup user settings.
+function M.setup(opts)
+  -- Look up keys in user-defined table with fallback to defaults.
+  M.opts = setmetatable(opts, {__index = defaults})
+end
+
+-- Allows to override global options with user local overrides.
+local function get_command_opts(local_opts)
+  -- In case, local opts are defined, chain opts lookup: [user_local] -> [user_global] -> [default]
+  return local_opts and setmetatable(local_opts, {__index = M.opts}) or M.opts
+end
+
+-- Display error messages.
+local function eprintln(opts, msg)
+  if opts.teasing then
+    vim.cmd(string.format('echohl Error|echo "%s"', msg))
+  end
+end
+
+-- Grey everything out to prepare the Hop session.
+--
+-- - hl_ns is the highlight namespace.
+-- - top_line is the top line in the buffer to start highlighting at
+-- - bottom_line is the bottom line in the buffer to stop highlighting at
+local function grey_things_out(buf_handle, hl_ns, top_line, bottom_line)
+  for line_i = top_line, bottom_line do
+    vim.api.nvim_buf_add_highlight(buf_handle, hl_ns, 'HopUnmatched', line_i, 0, -1)
+  end
+end
+
+-- Cleanup Hop highlights and unmark the buffer.
+local function unhl_and_unmark(buf_handle, hl_ns, top_line, bot_line)
+  vim.api.nvim_buf_clear_namespace(buf_handle, hl_ns, top_line, bot_line)
+  vim.api.nvim_buf_del_var(buf_handle, 'hop#marked')
+end
+
+local function hint_with(hint_mode, opts)
+  -- first, we ensure we’re not already hopping around; if not, we mark the current buffer (this mark will be removed
+  -- when a jump is performed or if the user stops hopping)
+  -- abort if we’re already hopping
+  if vim.b['hop#marked'] then
+    eprintln(opts, 'eh, don’t open hop from within hop, that’s super dangerous!')
+    return
+  end
+
+  vim.api.nvim_buf_set_var(0, 'hop#marked', true)
+
+  -- get a bunch of information about the window and the cursor
+  local win_info = vim.fn.getwininfo(vim.api.nvim_get_current_win())[1]
+  local win_view = vim.fn.winsaveview()
+  local top_line = win_info.topline - 1
+  local bot_line = win_info.botline - 1
+  local cursor_pos = vim.api.nvim_win_get_cursor(0)
+
+  -- NOTE: due to an (unknown yet) bug in neovim, the sign_width is not correctly reported when shifting the window
+  -- view inside a non-wrap window, so we can’t rely on this; for this reason, we have to implement a weird hack that
+  -- is going to disable the signs while hop is running (I’m sorry); the state is restored after jump
+  -- local left_col_offset = win_info.variables.context.number_width + win_info.variables.context.sign_width
+  local win_width = nil
+
+  -- hack to get the left column offset in nowrap
+  if not vim.wo.wrap then
+    vim.api.nvim_win_set_cursor(0, { cursor_pos[1], 0 })
+    local left_col_offset = vim.fn.wincol() - 1
+    vim.fn.winrestview(win_view)
+    win_width = win_info.width - left_col_offset
+  end
+
+  -- create the highlight group and grey everything out; the highlight group will allow us to clean everything at once
+  -- when hop quits
+  local hl_ns = vim.api.nvim_create_namespace('')
+  grey_things_out(0, hl_ns, top_line, bot_line)
+
+  -- get the buffer lines and create hints; hint_counts allows us to display some error diagnostics to the user, if any,
+  -- or even perform direct jump in the case of a single match
+  local win_lines = vim.api.nvim_buf_get_lines(0, top_line, bot_line + 1, false)
+  local hints, hint_counts = hint.create_hints(
+    hint_mode,
+    win_width,
+    #win_lines,
+    cursor_pos,
+    win_view.leftcol,
+    top_line,
+    win_lines,
+    opts
+  )
+
+  if hint_counts == 0 then
+    eprintln(opts, 'there’s no such thing we can see…')
+    unhl_and_unmark(0, hl_ns, top_line, bot_line)
+    return
+  elseif opts.jump_on_sole_occurrence and hint_counts == 1 then
+    -- search the hint and jump to it
+    for _, line_hints in pairs(hints) do
+      if #line_hints.hints == 1 then
+        local h = line_hints.hints[1]
+        unhl_and_unmark(0, hl_ns, top_line, bot_line)
+        vim.api.nvim_win_set_cursor(0, { h.line + 1, h.col - 1})
+        break
+      end
+    end
+
+    return
+  end
+
+  vim.api.nvim_buf_set_var(0, 'hop#hint_state', {
+    hints = hints;
+    hl_ns = hl_ns;
+    top_line = top_line;
+    bot_line = bot_line
+  })
+
+  hint.set_hint_extmarks(hl_ns, hints)
+  keymap.create_jump_keymap(0, opts)
+end
+
+-- Refine hints in the given buffer.
+--
+-- Refining hints allows to advance the state machine by one step. If a terminal step is reached, this function jumps to
+-- the location. Otherwise, it stores the new state machine.
+function M.refine_hints(buf_handle, key)
+  local hint_state = vim.api.nvim_buf_get_var(buf_handle, 'hop#hint_state')
+  local h, hints, update_count = hint.reduce_hints_lines(hint_state.hints, key)
+
+  if h == nil then
+    if update_count == 0 then
+      -- TODO: vim.fn.echo_hl doesn’t seem to be implemented right now :(
+      vim.cmd('echohl Error|echo "no remaining sequence starts with ' .. key .. '"')
+      return
+    end
+
+    hint_state.hints = hints
+    vim.api.nvim_buf_set_var(buf_handle, 'hop#hint_state', hint_state)
+
+    vim.api.nvim_buf_clear_namespace(buf_handle, hint_state.hl_ns, hint_state.top_line, hint_state.bot_line)
+    grey_things_out(buf_handle, hint_state.hl_ns, hint_state.top_line, hint_state.bot_line)
+    hint.set_hint_extmarks(hint_state.hl_ns, hints)
+  else
+    M.quit(buf_handle)
+
+    -- prior to jump, register the current position into the jump list
+    vim.cmd("normal m'")
+
+    -- JUMP!
+    vim.api.nvim_win_set_cursor(0, { h.line + 1, h.col - 1})
+  end
+end
+
+-- Quit Hop and delete its resources.
+--
+-- This works only if the current buffer is Hop one.
+function M.quit(buf_handle)
+  local hint_state = vim.api.nvim_buf_get_var(buf_handle, 'hop#hint_state')
+  unhl_and_unmark(buf_handle, hint_state.hl_ns, hint_state.top_line, hint_state.bot_line + 1)
+  keymap.restore_keymap(buf_handle)
+end
+
+function M.hint_words(opts)
+  hint_with(hint.by_word_start, get_command_opts(opts))
+end
+
+function M.hint_words(opts)
+  hint_with(hint.by_word_start, get_command_opts(opts))
+end
+
+function M.hint_patterns(opts)
+  local pat = vim.fn.input('Search: ')
+  hint_with(hint.by_searching(pat), get_command_opts(opts))
+end
+
+function M.hint_char1(opts)
+  local c = vim.fn.nr2char(vim.fn.getchar())
+  hint_with(hint.by_searching(c, true), get_command_opts(opts))
+end
+
+function M.hint_char2(opts)
+  local a = vim.fn.nr2char(vim.fn.getchar())
+  local b = vim.fn.nr2char(vim.fn.getchar())
+  hint_with(hint.by_searching(a .. b, true), get_command_opts(opts))
+end
+
+function M.hint_lines(opts)
+  hint_with(hint.by_line_start, get_command_opts(opts))
+end
+
+return M

--- a/lua/hop/keymap.lua
+++ b/lua/hop/keymap.lua
@@ -1,0 +1,58 @@
+local M = {}
+
+-- Create the keymap based on the input keys and insert it in the input buffer via its handle.
+--
+-- This function creates the keymap allowing a user to:
+--
+-- - Jump to a target hint.
+-- - Quit with q.
+function M.create_jump_keymap(buf_handle, opts)
+  local keys = opts.keys
+
+  -- save the keymaps to be able to restore them later
+  local prev_keymap = vim.api.nvim_buf_get_keymap(buf_handle, '')
+  vim.api.nvim_buf_set_var(buf_handle, 'hop#prev_keymap', prev_keymap)
+  local keymap = {}
+
+  -- remap all the jump keys
+  for i = 1, #keys do
+    local key = keys:sub(i, i)
+    keymap[#keymap + 1] = key
+    vim.api.nvim_buf_set_keymap(buf_handle, '', key, "<cmd>lua require'hop'.refine_hints(0, '" .. key .. "')<cr>", { nowait = true })
+  end
+
+  vim.api.nvim_buf_set_keymap(buf_handle, '', '<esc>', "<cmd>lua require'hop'.quit(0)<cr>", {})
+  keymap[#keymap + 1] = '<esc>'
+
+  vim.api.nvim_buf_set_var(buf_handle, 'hop#keymap', keymap)
+end
+
+local function find_mapping(keymap, lhs)
+  for _, m in pairs(keymap) do
+    if m.lhs == lhs then
+      return m
+    end
+  end
+
+  return nil
+end
+
+function M.restore_keymap(buf_handle)
+  local prev_keymap = vim.api.nvim_buf_get_var(buf_handle, 'hop#prev_keymap')
+  local keymap = vim.api.nvim_buf_get_var(buf_handle, 'hop#keymap')
+
+  for _, lhs in pairs(keymap) do
+    local mapping = find_mapping(prev_keymap, lhs)
+
+    if mapping ~= nil then
+      vim.api.nvim_buf_set_keymap(buf_handle, '', lhs, mapping.rhs, { silent = mapping.silent == 1; noremap = mapping.noremap == 1; script = mapping.script == 1; expr = mapping.expr == 1 })
+    else
+      vim.api.nvim_buf_del_keymap(buf_handle, '', lhs)
+    end
+  end
+
+  vim.api.nvim_buf_del_var(buf_handle, 'hop#keymap')
+  vim.api.nvim_buf_del_var(buf_handle, 'hop#prev_keymap')
+end
+
+return M

--- a/lua/hop/perm.lua
+++ b/lua/hop/perm.lua
@@ -1,0 +1,104 @@
+local defaults = require'hop.defaults'
+
+local M = {}
+
+-- Get the first key of a key set.
+local function first_key(keys)
+  return keys:sub(1, 1)
+end
+
+-- Get the next key of the input key in the input key set, if any, or return nil.
+local function next_key(keys, key)
+  local i = keys:find(key)
+
+  if i == #keys then
+    return nil
+  end
+
+  local i1 = i + 1
+  return keys:sub(i1, i1)
+end
+
+-- Generate the next permutation.
+--
+-- term_keys is the terminal key set, seq_keys is the sequence key set and perm is the permutation for which we want
+-- the next one.
+--
+-- The way this works is by incrementing a permutation as long it its terminal key has a next available key. A sequence
+-- key is a key in the last ¼ part of the initial key set. For instance, for keys = "abcdefghijklmnop", "mnop" is the
+-- last ¼ part, so those keys will be used as sequence keys. The invariant is that, terminal sequences cannot share
+-- their last key with non-terminal sequences on the same level. The following are then not possible (given the example
+-- keys from above):
+--
+-- - "a", "ab": not possible because even though "b" is okay, "a" is terminal for the first sequence, so it cannot be
+--   used in the second.
+-- - "a", "ma", "mb", mc": okay, as "a" is not shared on the same level.
+-- - "pnac": without even going any further, this sequence is not possible as "a" is only used in terminal sequences, so
+--   this "pnac" sequence would collide with the correct "pna" sequence.
+--
+-- Yet an another – easier – way to picture the idea is that any key from the terminal key set can only appear at the end
+-- of sequence, and any key from the sequence key set can only appear before a terminal key in a sequence.
+local function next_perm(term_keys, seq_keys, perm)
+  local perm_len = #perm
+
+  if perm_len == 0 then
+    return { first_key(term_keys) }
+  end
+
+  -- try to increment the terminal key; if it’s possible, then we can directly return the permutation as it’s the next
+  -- one
+  local term_key = next_key(term_keys, perm[perm_len])
+
+  if term_key then
+    perm[perm_len] = term_key
+
+    return perm
+  end
+
+  -- perm was the last permutation for the current sequence keys, so we need to backtrack and increment sequence keys
+  -- until one of them has a successor
+  for i = perm_len - 1, 1, -1 do
+    -- increment the sequence key; if it’s possible, then we have found the next permutation
+    local seq_key = next_key(seq_keys, perm[i])
+
+    if seq_key then
+      -- set the terminal key to the first terminal key as we’re starting a new sequence
+      perm[perm_len] = first_key(term_keys)
+      perm[i] = seq_key
+
+      return perm
+    else
+      -- the current sequence key doesn’t have a successor, so we set it back to the first sequence key because we will
+      -- start a new sequence key either incrementing a parent of the current sequence key, or we will make a complete
+      -- new permutation by incrementing its dimension
+      perm[i] = first_key(seq_keys)
+    end
+  end
+
+  -- we need to increment the dimension
+  perm[perm_len] = first_key(seq_keys)
+  perm[perm_len + 1] = first_key(term_keys)
+
+  return perm
+end
+
+-- Get the first N permutations for a given set of keys.
+--
+-- Permutations are sorted by dimensions, so you will get 1-perm first, then 2-perm, 3-perm, etc. depending on the size
+-- of the keys.
+function M.permutations(keys, n, opts)
+  local quarter = #keys * opts.term_seq_bias
+  local term_keys = keys:sub(1, quarter)
+  local seq_keys = keys:sub(quarter + 1)
+  local perms = {}
+  local perm = {}
+
+  for _ = 1, n do
+    perm = next_perm(term_keys, seq_keys, perm)
+    perms[#perms + 1] = vim.deepcopy(perm)
+  end
+
+  return perms
+end
+
+return M

--- a/plugin/hop.vim
+++ b/plugin/hop.vim
@@ -1,0 +1,40 @@
+if !has('nvim')
+  echohl Error
+  echom 'This plugin only works with Neovim'
+  echohl clear
+  finish
+endif
+
+" The jump-to-word command.
+command! HopWord lua require'hop'.hint_words()
+
+" The jump-to-pattern command.
+command! HopPattern lua require'hop'.hint_patterns()
+
+" The jump-to-char-1 command.
+command! HopChar1 lua require'hop'.hint_char1()
+
+" The jump-to-char-2 command.
+command! HopChar2 lua require'hop'.hint_char2()
+
+" The jump-to-line command.
+command! HopLine lua require'hop'.hint_lines()
+
+" Reset highlighting after loading a new color scheme
+function! hop#highlight_init()
+    " Highlight used for the mono-sequence keys (i.e. sequence of 1).
+    highlight default HopNextKey  guifg=#ff007c gui=bold,underline
+
+    " Highlight used for the first key in a sequence.
+    highlight default HopNextKey1 guifg=#00dfff gui=bold,underline
+
+    " Highlight used for the second and remaining keys in a sequence.
+    highlight default HopNextKey2 guifg=#2b8db3
+
+    " Highlight used for the unmatched part of the buffer.
+    highlight default HopUnmatched guifg=#666666
+endfunction
+augroup HopInitHighlight
+    autocmd!
+    autocmd ColorScheme * call hop#highlight_init()
+augroup end


### PR DESCRIPTION
Some colorscheme uses `hi clear` before setting highlights as a standard way. 

That leads to hop.nvim's highlights cleared. 

This commit prevents the problem by using `autocmd ColorScheme` that triggered after loading a new color scheme.

fix #35