### PR TITLE
Reset highlighting after loading a new color scheme. #35

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -110,6 +110,7 @@ The Lua API comprises several modules:
               read any other modules.
 `hop.defaults`  Default options.
 `hop.hint`      Various functions to create, update and reduce hints.
+`hop.highlight` Highlight functions (creation / autocommands / etc.).
 `hop.keymap`    Implementation of the keymap allowing to perform jumps.
 `hop.perm`      Permutation functions. Permutations are used as labels for
               the hints.
@@ -250,6 +251,20 @@ The hint API allows to create, reduce and display *hints* in easy ways.
 
     This function returns the content of the buffer as a list of lines, and
     each line is represented with a single string.
+
+Highlight API~
+
+The highlight API gives two functions to manipulate the highlights Hop uses:
+
+`hop.highlight.insert_highlights()`             *hop.highlight.insert_highlights*
+    Manually insert the highlights by calling the `highlight default` command.
+    See |hop-highlights| for further details about the list of highlights
+    currently available.
+
+`hop.highlight.create_autocmd`                     *hop.highlight.create_autocmd*
+    Register autocommands for the `ColorScheme` event, calling
+    |hop.highlight.insert_highlights|. This is called when you require Hop and
+    you shouldn’t need to call this function by yourself.
 
 Permutation API~
 

--- a/lua/hop/highlight.lua
+++ b/lua/hop/highlight.lua
@@ -1,0 +1,26 @@
+-- This module contains everything for highlighting Hop.
+local M = {}
+
+-- Insert the highlights that Hop uses.
+function M.insert_highlights()
+  -- Highlight used for the mono-sequence keys (i.e. sequence of 1).
+  vim.api.nvim_command('highlight default HopNextKey  guifg=#ff007c gui=bold,underline')
+
+  -- Highlight used for the first key in a sequence.
+  vim.api.nvim_command('highlight default HopNextKey1 guifg=#00dfff gui=bold,underline')
+
+  -- Highlight used for the second and remaining keys in a sequence.
+  vim.api.nvim_command('highlight default HopNextKey2 guifg=#2b8db3')
+
+  -- Highlight used for the unmatched part of the buffer.
+  vim.api.nvim_command('highlight default HopUnmatched guifg=#666666')
+end
+
+function M.create_autocmd()
+  vim.api.nvim_command('augroup HopInitHighlight')
+  vim.api.nvim_command('autocmd!')
+  vim.api.nvim_command("autocmd ColorScheme * lua require'hop.highlight'.insert_highlights()")
+  vim.api.nvim_command('augroup end')
+end
+
+return M

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -191,4 +191,9 @@ function M.hint_lines(opts)
   hint_with(hint.by_line_start, get_command_opts(opts))
 end
 
+-- Insert the highlights and register the autocommand.
+local highlight = require'hop.highlight'
+highlight.insert_highlights()
+highlight.create_autocmd()
+
 return M

--- a/plugin/hop.vim
+++ b/plugin/hop.vim
@@ -19,23 +19,3 @@ command! HopChar2 lua require'hop'.hint_char2()
 
 " The jump-to-line command.
 command! HopLine lua require'hop'.hint_lines()
-
-" Reset highlighting after loading a new color scheme
-function! hop#highlight_init()
-    " Highlight used for the mono-sequence keys (i.e. sequence of 1).
-    highlight default HopNextKey  guifg=#ff007c gui=bold,underline
-
-    " Highlight used for the first key in a sequence.
-    highlight default HopNextKey1 guifg=#00dfff gui=bold,underline
-
-    " Highlight used for the second and remaining keys in a sequence.
-    highlight default HopNextKey2 guifg=#2b8db3
-
-    " Highlight used for the unmatched part of the buffer.
-    highlight default HopUnmatched guifg=#666666
-endfunction
-augroup HopInitHighlight
-    autocmd!
-    autocmd ColorScheme * call hop#highlight_init()
-augroup end
-call hop#highlight_init()

--- a/plugin/hop.vim
+++ b/plugin/hop.vim
@@ -20,14 +20,22 @@ command! HopChar2 lua require'hop'.hint_char2()
 " The jump-to-line command.
 command! HopLine lua require'hop'.hint_lines()
 
-" Highlight used for the mono-sequence keys (i.e. sequence of 1).
-highlight default HopNextKey  guifg=#ff007c gui=bold,underline
+" Reset highlighting after loading a new color scheme
+function! hop#highlight_init()
+    " Highlight used for the mono-sequence keys (i.e. sequence of 1).
+    highlight default HopNextKey  guifg=#ff007c gui=bold,underline
 
-" Highlight used for the first key in a sequence.
-highlight default HopNextKey1 guifg=#00dfff gui=bold,underline
+    " Highlight used for the first key in a sequence.
+    highlight default HopNextKey1 guifg=#00dfff gui=bold,underline
 
-" Highlight used for the second and remaining keys in a sequence.
-highlight default HopNextKey2 guifg=#2b8db3
+    " Highlight used for the second and remaining keys in a sequence.
+    highlight default HopNextKey2 guifg=#2b8db3
 
-" Highlight used for the unmatched part of the buffer.
-highlight default HopUnmatched guifg=#666666
+    " Highlight used for the unmatched part of the buffer.
+    highlight default HopUnmatched guifg=#666666
+endfunction
+augroup HopInitHighlight
+    autocmd!
+    autocmd ColorScheme * call hop#highlight_init()
+augroup end
+call hop#highlight_init()


### PR DESCRIPTION
Some colorscheme uses hi clear before setting highlights as a standard way.

That leads to hop.nvim's highlights cleared.

This PR prevents the problem by using autocmd ColorScheme that triggered after loading a new color scheme.

fix #35 