### PR TITLE
Use noremap normal command to avoid collision with user keymaps.

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -171,7 +171,7 @@ function M.refine_hints(buf_handle, key)
     M.quit(buf_handle)
 
     -- prior to jump, register the current position into the jump list
-    vim.cmd("normal m'")
+    vim.cmd("normal! m'")
 
     -- JUMP!
     vim.api.nvim_win_set_cursor(0, { h.line + 1, h.col - 1})


### PR DESCRIPTION
Using the non-recursive version in case the user has `m` remapped.

Fixes #49 