### PR TITLE
Use extmarks with high priority to grey out text.

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -36,9 +36,9 @@ end
 -- - bottom_line is the bottom line in the buffer to stop highlighting at
 local function grey_things_out(buf_handle, hl_ns, top_line, bottom_line)
   clear_namespace(buf_handle, hl_ns)
-  for line_i = top_line, bottom_line do
-    vim.api.nvim_buf_add_highlight(buf_handle, hl_ns, 'HopUnmatched', line_i, 0, -1)
-  end
+  -- Set Priority really high to override other highlight groups, bottom_line+1 to avoid getting length of last line.
+  vim.api.nvim_buf_set_extmark(buf_handle, hl_ns, top_line, 0,
+    {end_line=bottom_line+1, hl_group="HopUnmatched", priority=10000})
 end
 
 -- Cleanup Hop highlights and unmark the buffer.

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -36,7 +36,10 @@ end
 -- - bottom_line is the bottom line in the buffer to stop highlighting at
 local function grey_things_out(buf_handle, hl_ns, top_line, bottom_line)
   clear_namespace(buf_handle, hl_ns)
-  -- Set Priority really high to override other highlight groups, bottom_line+1 to avoid getting length of last line.
+  -- Set Priority absurdly high to surely override all highlighting, 10000 just
+  -- because it was the first number that worked.
+  -- (shouldn't really be necessary, but there seems to be some bug upstream).
+  -- bottom_line+1 to avoid getting length of last line.
   vim.api.nvim_buf_set_extmark(buf_handle, hl_ns, top_line, 0,
     {end_line=bottom_line+1, hl_group="HopUnmatched", priority=10000})
 end


### PR DESCRIPTION
Hi, I noticed that sometimes, not all highlighting was replaced by 'HopUnmatched'.
I'm not entirely sure what caused this behaviour, but highlighting with higher priority seems to fix it.

Without changes:
![without](https://user-images.githubusercontent.com/41961280/113872000-bfef4000-97b3-11eb-884c-d0739a4d7922.png)
With changes:
![with](https://user-images.githubusercontent.com/41961280/113872149-e90fd080-97b3-11eb-84c2-3ccd180bf1ba.png)
Amazing Plugin btw.
