### PR TITLE
Make special keys quit hop and add a quit_key config option

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -413,6 +413,9 @@ below.
     	part of it will be used for terminal keys and the second part for sequence
     	keys.
 
+    Warning: Don't add special keys like <C-Space> and <Esc> to `keys` as it
+    won't always work correctly, even if you use |nvim_replace_termcodes()|.
+
     Defaults:~
         `keys = 'asdghklqwertyuiopzxcvbnmfj'`
 

--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -413,11 +413,33 @@ below.
     	part of it will be used for terminal keys and the second part for sequence
     	keys.
 
-    Warning: Don't add special keys like <C-Space> and <Esc> to `keys` as it
-    won't always work correctly, even if you use |nvim_replace_termcodes()|.
-
     Defaults:~
         `keys = 'asdghklqwertyuiopzxcvbnmfj'`
+
+`quit_key`                                                   *hop-config-quit_key*
+    A string representing a key that will quit Hop mode without also feeding
+    that key into Neovim to be treated as a normal key press.
+
+    It is possible to quit hopping by pressing any key that is not present in
+    |hop-config-keys|; however, when you do this, the keys normal function is
+    also performed. For example if, hopping in |visual-mode|, pressing <Esc> will
+    quit hopping and also exit |visual-mode|.
+
+    If the user presses `quit_key`, Hop will be quit without the keys normal
+    function being performed. For example if hopping in |visual-mode| with
+    `quit_key` set to '<Esc>', pressing <Esc> will quit hopping without
+    quitting |visual-mode|.
+
+    If you don't want to use a `quit_key`, set `quit_key` to an empty string.
+
+    Note:~
+        `quit_key` should only contain a single key or be an empty string.
+    Note:~
+        `quit_key` should not contain a key that is also present in
+        |hop-config-keys|.
+
+    Defaults:~
+        `quit_key = '<Esc>'`
 
 `perm_method`                                             *hop-config-perm_method*
     Permutation method to use.

--- a/lua/hop/defaults.lua
+++ b/lua/hop/defaults.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 M.keys = 'asdghklqwertyuiopzxcvbnmfj'
+M.quit_key = '<Esc>'
 M.perm_method = require'hop.perm'.TrieBacktrackFilling
 M.reverse_distribution = false
 M.term_seq_bias = 3 / 4

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -155,25 +155,30 @@ local function hint_with(hint_mode, opts)
       M.quit(0)
       break
     end
+    local not_special_key = true
     -- :h getchar(): "If the result of expr is a single character, it returns a
-    -- number. Use nr2char() to convert it to a String."
+    -- number. Use nr2char() to convert it to a String." Also the result is a
+    -- special key if it's a string and its first byte is 128.
     --
     -- Note of caution: Even though the result of `getchar()` might be a single
     -- character, that character might still be multiple bytes.
     if type(key) == 'number' then
-      local key_str = vim.fn.nr2char(key)
-      if opts.keys:find(key_str, 1, true) then
-        -- If this is a key used in hop (via opts.keys), deal with it in hop
-        h = M.refine_hints(0, key_str, opts.teasing, direction_mode)
-        vim.cmd('redraw')
-      else
-        -- If it's not, quit hop and use the key like normal instead
-        M.quit(0)
-        -- Pass the key captured via getchar() through to nvim, to be handled
-        -- normally (including mappings)
-        vim.api.nvim_feedkeys(key_str, '', true)
-        break
-      end
+      key = vim.fn.nr2char(key)
+    elseif key:byte() == 128 then
+      not_special_key = false
+    end
+
+    if not_special_key and opts.keys:find(key, 1, true) then
+      -- If this is a key used in hop (via opts.keys), deal with it in hop
+      h = M.refine_hints(0, key, opts.teasing, direction_mode)
+      vim.cmd('redraw')
+    else
+      -- If it's not, quit hop and use the key like normal instead
+      M.quit(0)
+      -- Pass the key captured via getchar() through to nvim, to be handled
+      -- normally (including mappings)
+      vim.api.nvim_feedkeys(key, '', true)
+      break
     end
   end
 end

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -173,11 +173,13 @@ local function hint_with(hint_mode, opts)
       h = M.refine_hints(0, key, opts.teasing, direction_mode)
       vim.cmd('redraw')
     else
-      -- If it's not, quit hop and use the key like normal instead
+      -- If it's not, quit hop
       M.quit(0)
-      -- Pass the key captured via getchar() through to nvim, to be handled
-      -- normally (including mappings)
-      vim.api.nvim_feedkeys(key, '', true)
+      -- If the key captured via getchar() is not the quit_key, pass it through
+      -- to nvim to be handled normally (including mappings)
+      if key ~= vim.api.nvim_replace_termcodes(opts.quit_key, true, false, true) then
+        vim.api.nvim_feedkeys(key, '', true)
+      end
       break
     end
   end


### PR DESCRIPTION
The first commit makes it so that when hopping, typing a special key like `<C-Space>` or `<Left>` will quit hopping. Previously hop would eat the key and do nothing with it.

The second commit adds a quit_key config option. The effect of this is that pressing the quit_key when hopping will quit hop without feeding the key through to neovim.
For example, I have `<C-Space>` mapped to `<Esc>` in visual mode. When hopping in visual mode, I want to be able to use `<C-Space>` to quit hopping without feeding that through which would also exit visual mode. This commit allows for that.