### PR TITLE
Add default colors for cterm

### DIFF
--- a/lua/hop/highlight.lua
+++ b/lua/hop/highlight.lua
@@ -4,16 +4,16 @@ local M = {}
 -- Insert the highlights that Hop uses.
 function M.insert_highlights()
   -- Highlight used for the mono-sequence keys (i.e. sequence of 1).
-  vim.api.nvim_command('highlight default HopNextKey  guifg=#ff007c gui=bold,underline')
+  vim.api.nvim_command('highlight default HopNextKey  guifg=#ff007c gui=bold,underline ctermfg=198 cterm=bold,underline')
 
   -- Highlight used for the first key in a sequence.
-  vim.api.nvim_command('highlight default HopNextKey1 guifg=#00dfff gui=bold,underline')
+  vim.api.nvim_command('highlight default HopNextKey1 guifg=#00dfff gui=bold,underline ctermfg=45 cterm=bold,underline')
 
   -- Highlight used for the second and remaining keys in a sequence.
-  vim.api.nvim_command('highlight default HopNextKey2 guifg=#2b8db3')
+  vim.api.nvim_command('highlight default HopNextKey2 guifg=#2b8db3 ctermfg=33')
 
   -- Highlight used for the unmatched part of the buffer.
-  vim.api.nvim_command('highlight default HopUnmatched guifg=#666666')
+  vim.api.nvim_command('highlight default HopUnmatched guifg=#666666 ctermfg=242')
 end
 
 function M.create_autocmd()


### PR DESCRIPTION
Wanted to add some default support for `notermguicolors` users like me.  :) This adds `ctermfg` and `cterm` options to the default highlights.