### PR TITLE
don't error on empty invocation of setup

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -264,7 +264,7 @@ end
 M.opts = defaults
 function M.setup(opts)
   -- Look up keys in user-defined table with fallback to defaults.
-  M.opts = setmetatable(opts, {__index = defaults})
+  M.opts = setmetatable(opts or {}, {__index = defaults})
 
   -- Insert the highlights and register the autocommand if asked to.
   local highlight = require'hop.highlight'


### PR DESCRIPTION
calling like this `require('hop').setup()` instead of this `require('hop').setup{}` currently errors