### PR TITLE
Fix truncated hints after unicode in wrap mode.

### DIFF
--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -105,7 +105,7 @@ function M.mark_hints_line(hint_mode, line_nr, line, col_offset, win_width)
     end_index = vim.fn.strdisplaywidth(line)
   end
 
-  local shifted_line = line:sub(1 + col_offset, end_index)
+  local shifted_line = line:sub(1 + col_offset, vim.fn.byteidx(line, end_index))
 
   local col = 1
   while true do


### PR DESCRIPTION
If some unicode / multi-byte is present at column `col` on a given line
and that `wrap` is set, then after `col`, some hints will be truncated.
This was implemented in the first place to hint _only_ what’s visible
(so that we don’t waste time hinting stuff the user cannot even see). In
the case of `wrap` mode, the computation of what’s visible was buggy.

This commit patches this situation by converting the width into a byte
width, allowing to take into unicode and more specifically, multi-byte
fucking characters. Should work with emojis, too.

Relates to #72.

# Bonus

Test with emojis, because why not lol.

![Screenshot_20210603_003759](https://user-images.githubusercontent.com/506592/120560987-0f449c00-c404-11eb-91de-a3044c656fea.png)
