### PR TITLE
Add HintDirection and read it from opts.

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -66,7 +66,13 @@ You can try those commands by typing them in your command line. By default,
 they will use the default options for the configuration of Hop. If you want to
 customize how those functions work, have a look at |hop.setup|.
 
+Some of the commands have a suffix, such as `BC` and `AC`. Those are
+variations of the command without the suffix, applying to the visible part of
+the buffer before and after the cursor, respectively.
+
 `:HopWord`                                                              *:HopWord*
+`:HopWordBC`                                                          *:HopWordBC*
+`:HopWordAC`                                                          *:HopWordAC*
     Annotate all words in the current window with key sequences. Typing a
     first  key will visually filter the sequences and reduce them. Continue
     typing key sequences until you reduce a sequence completely, which will
@@ -75,21 +81,29 @@ customize how those functions work, have a look at |hop.setup|.
     This is akin to calling the |hop.hint_words| Lua function.
 
 `:HopPattern`                                                        *:HopPattern*
+`:HopPatternBC`                                                    *:HopPatternBC*
+`:HopPatternAC`                                                    *:HopPatternAC*
     Ask the user for a pattern and hint the document with it.
 
     This is akin to calling the |hop.hint_patterns| Lua function.
 
 `:HopChar1`                                                            *:HopChar1*
+`:HopChar1BC`                                                        *:HopChar1BC*
+`:HopChar1AC`                                                        *:HopChar1AC*
     Type a key and immediately hint the document for this key.
 
     This is akin to calling the |hop.hint_char1| Lua Function
 
 `:HopChar2`                                                            *:HopChar2*
+`:HopChar2BC`                                                        *:HopChar2BC*
+`:HopChar2AC`                                                        *:HopChar2AC*
     Type two keys and immediately hint the document for this bigram.
 
     This is akin to calling the |hop.hint_char2| Lua Function
 
 `:HopLine`                                                              *:HopLine*
+`:HopLineBC`                                                          *:HopLineBC*
+`:HopLineAC`                                                          *:HopLineAC*
     Jump to the beginning of the line of your choice inside your buffer.
 
     This is akin to calling the |hop.hint_lines| Lua function.
@@ -178,17 +192,31 @@ Hint API~
 The hint API allows to create, reduce and display *hints* in easy ways.
 
 `hop.hint.by_word_start`                                  *hop.hint.by_word_start*
-        |word| hint mode. This mode will highlights the beginnings of all the
-        words in the document and will make the cursor jump to the one fully
-        reduced.
+    |word| hint mode. This mode will highlights the beginnings of all the
+    words in the document and will make the cursor jump to the one fully
+    reduced.
 
-`hop.hint.by_searching(`{pat}`)`                             *hop.hint.by_searching*
-        |pattern| hint mode. This mode will highlights the beginnings of a
-        pattern you will be prompted for in the document and will make the
-        cursor jump to the one fully reduced.
+`hop.hint.by_searching(`{pat}`,` {plain_search}`)`             *hop.hint.by_searching*
+    |pattern| hint mode. This mode will highlights the beginnings of a
+    pattern you will be prompted for in the document and will make the
+    cursor jump to the one fully reduced.
 
     Arguments:~
-        {pat}  Pattern to search.
+        {pat}          Pattern to search.
+        {plain_search} Should the pattern by plain-text.
+
+`hop.hint.by_case_searching(`                         *hop.hint.by_case_searching*
+  {pat}`,`
+  {plain_search}`,`
+  {opts}
+`)
+    Similar to |hop.hint.by_searching|, but respects the user case sensitivity
+    set by 'smartcase' and |hop-config-case_insensitive|.
+
+    Arguments:~
+        {pat}          Pattern to search.
+        {plain_search} Should the pattern by plain-text.
+        {opts}         User options.
 
 `hop.hint.mark_hints_line(`                             *hop.hint.mark_hints_line*
   {hint_mode}`,`
@@ -265,6 +293,13 @@ The hint API allows to create, reduce and display *hints* in easy ways.
         was possible), and `update_count` is the number of changes that have
         occurred while reducing.
 
+`hop.hint.HintDirection`                                  *hop.hint.HintDirection*
+    Enumeration for hinting direction.
+
+    Enumeration variants:~
+        {BEFORE_CURSOR} Create and apply hints before the cursor.
+        {AFTER_CURSOR}  Create and apply hints after the cursor.
+
 `hop.hint.create_hints(`                                   *hop.hint.create_hints*
   {hint_mode}`,`
   {win_width}`,`
@@ -272,6 +307,7 @@ The hint API allows to create, reduce and display *hints* in easy ways.
   {col_offset}`,`
   {top_line}`,`
   {lines}`,`
+  {direction},
   {opts}
 `)`
     Given a set of {lines}, this function creates the hints for each line in
@@ -285,6 +321,7 @@ The hint API allows to create, reduce and display *hints* in easy ways.
         {col_offset}  Left column offset in the buffer to start at.
         {top_line}    First line in the buffer to create hints for.
         {lines}       Lines to create hints for.
+        {direction}   Direction to hint in. See |hop.hint.HintDirection|.
         {opts}        Hop options.
 
     Return:~
@@ -484,6 +521,16 @@ below.
 >
         create_hl_autocmd = true
 <
+`direction`                                                *hop-config-direction*
+    Direction in which to hint. See |hop.hint.HintDirection| for further
+    details.
+
+    Setting this in the user configuration will make all commands default to
+    that direction, unless overriden.
+
+    Defaults:~
+
+        {none}
 
 ==============================================================================
 HIGHLIGHTS                                                      *hop-highlights*

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -40,6 +40,14 @@ local function unhl_and_unmark(buf_handle, hl_ns)
   vim.api.nvim_buf_del_var(buf_handle, 'hop#marked')
 end
 
+M.HintDirection = {
+  BEFORE_CURSOR = 1,
+  AFTER_CURSOR = 2,
+}
+
+-- Hint the whole visible part of the buffer.
+--
+-- The 'hint_mode' argument is the mode to use to hint the buffer.
 local function hint_with(hint_mode, opts)
   -- first, we ensure we’re not already hopping around; if not, we mark the current buffer (this mark will be removed
   -- when a jump is performed or if the user stops hopping)
@@ -57,6 +65,14 @@ local function hint_with(hint_mode, opts)
   local top_line = win_info.topline - 1
   local bot_line = win_info.botline - 1
   local cursor_pos = vim.api.nvim_win_get_cursor(0)
+
+  -- adjust the visible part of the buffer to hint based on the direction
+  local direction = opts.direction
+  if direction == M.HintDirection.BEFORE_CURSOR then
+    bot_line = cursor_pos[1] - 1
+  elseif direction == M.HintDirection.AFTER_CURSOR then
+    top_line = cursor_pos[1] - 1
+  end
 
   -- NOTE: due to an (unknown yet) bug in neovim, the sign_width is not correctly reported when shifting the window
   -- view inside a non-wrap window, so we can’t rely on this; for this reason, we have to implement a weird hack that

--- a/plugin/hop.vim
+++ b/plugin/hop.vim
@@ -7,15 +7,25 @@ endif
 
 " The jump-to-word command.
 command! HopWord lua require'hop'.hint_words()
+command! HopWordBC lua require'hop'.hint_words({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
+command! HopWordAC lua require'hop'.hint_words({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })
 
 " The jump-to-pattern command.
 command! HopPattern lua require'hop'.hint_patterns()
+command! HopPatternBC lua require'hop'.hint_patterns({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
+command! HopPatternAC lua require'hop'.hint_patterns({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })
 
 " The jump-to-char-1 command.
 command! HopChar1 lua require'hop'.hint_char1()
+command! HopChar1BC lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
+command! HopChar1AC lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })
 
 " The jump-to-char-2 command.
 command! HopChar2 lua require'hop'.hint_char2()
+command! HopChar2BC lua require'hop'.hint_char2({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
+command! HopChar2AC lua require'hop'.hint_char2({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })
 
 " The jump-to-line command.
 command! HopLine lua require'hop'.hint_lines()
+command! HopLineBC lua require'hop'.hint_lines({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
+command! HopLineAC lua require'hop'.hint_lines({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })


### PR DESCRIPTION
This first commit allows to apply the hints to only the previous part of
the cursor or what comes after.

This commit doesn’t currently check the column, only the line. The next
commit will add support for before / after on the current line and
should also add support for a way to reduce apply hints only to the
current line.

This is an alternative implementation of #59.

Relates to #71, #91.

# Screenshoties

![Screenshot_20210619_024238](https://user-images.githubusercontent.com/506592/122625954-11675580-d0a8-11eb-801a-d67fb17d4a48.png)
![Screenshot_20210619_024224](https://user-images.githubusercontent.com/506592/122625956-11ffec00-d0a8-11eb-9df9-378de2f25ffe.png)
