### PR TITLE
Fix default `create_hl_autocmd` value not being utilized

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -270,7 +270,7 @@ function M.setup(opts)
   local highlight = require'hop.highlight'
   highlight.insert_highlights()
 
-  if opts.create_hl_autocmd then
+  if M.opts.create_hl_autocmd then
     highlight.create_autocmd()
   end
 end


### PR DESCRIPTION
Fixes https://github.com/phaazon/hop.nvim/issues/92#issuecomment-864527938
Also, improves #83, because calling `setup` without `{}` still throws an error, since `opts == nil`.