### PR TITLE
Implement HopLineStart

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -108,6 +108,14 @@ the buffer before and after the cursor, respectively.
 
     This is akin to calling the |hop.hint_lines| Lua function.
 
+`:HopLineStart`                                                         *:HopLine*
+`:HopLineStartBC`                                                     *:HopLineBC*
+`:HopLineStartAC`                                                     *:HopLineAC*
+    Like `HopLine` but skips leading whitespace on every line.
+    Blank lines are skipped over.
+
+    This is akin to calling the |hop.hint_lines_skip_whitespace| Lua function.
+
                                                                    *hop-lua-api*
 Lua API~
 

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -32,7 +32,7 @@ function M.by_searching(pat, plain_search)
   }
 end
 
--- Wrapper over M.by_searching to add spport for case sensitivity.
+-- Wrapper over M.by_searching to add support for case sensitivity.
 function M.by_case_searching(pat, plain_search, opts)
   if plain_search then
     pat = vim.fn.escape(pat, '\\/.$^~[]')
@@ -62,7 +62,7 @@ M.by_word_start = M.by_searching('\\w\\+')
 
 -- Line hint mode.
 --
--- Used to tag the beginning of each lines with ihnts.
+-- Used to tag the beginning of each lines with hints.
 M.by_line_start = {
   oneshot = true,
   match = function(_)

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -70,6 +70,19 @@ M.by_line_start = {
   end
 }
 
+-- Line hint mode skipping leading whitespace.
+--
+-- Used to tag the beginning of each lines with hints.
+function M.by_line_start_skip_whitespace()
+  pat = vim.regex("\\S")
+  return {
+    oneshot = true,
+    match = function(s)
+      return pat:match_str(s)
+    end
+  }
+end
+
 -- Turn a table representing a hint into a string.
 local function tbl_to_str(hint)
   local s = ''

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -248,6 +248,10 @@ function M.hint_lines(opts)
   hint_with(hint.by_line_start, get_command_opts(opts))
 end
 
+function M.hint_lines_skip_whitespace(opts)
+  hint_with(hint.by_line_start_skip_whitespace(), get_command_opts(opts))
+end
+
 -- Setup user settings.
 M.opts = defaults
 function M.setup(opts)

--- a/plugin/hop.vim
+++ b/plugin/hop.vim
@@ -29,3 +29,8 @@ command! HopChar2AC lua require'hop'.hint_char2({ direction = require'hop.hint'.
 command! HopLine lua require'hop'.hint_lines()
 command! HopLineBC lua require'hop'.hint_lines({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
 command! HopLineAC lua require'hop'.hint_lines({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })
+
+" The jump-to-line command.
+command! HopLineStart   lua require'hop'.hint_lines_skip_whitespace()
+command! HopLineStartBC lua require'hop'.hint_lines_skip_whitespace({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
+command! HopLineStartAC lua require'hop'.hint_lines_skip_whitespace({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })


### PR DESCRIPTION
Fixes #106.

This was easy indeed (I don't even speak `lua`) X)

I finally ended up skipping empty lines, because I never actually navigate to them, so I'm happy with this :)

Maybe you don't like that `HopLineStart(AC|BC)?` are three new commands? In this case, the "skip_lines_leading_whitespace" would be a general option instead?