### PR TITLE
Remove duplicated documentation tags.

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -129,9 +129,9 @@ the buffer before and after the cursor, respectively.
 
     This is akin to calling the |hop.hint_lines| Lua function.
 
-`:HopLineStart`                                                         *:HopLine*
-`:HopLineStartBC`                                                     *:HopLineBC*
-`:HopLineStartAC`                                                     *:HopLineAC*
+`:HopLineStart`                                                    *:HopLineStart*
+`:HopLineStartBC`                                                *:HopLineStartBC*
+`:HopLineStartAC`                                                *:HopLineStartAC*
     Like `HopLine` but skips leading whitespace on every line.
     Blank lines are skipped over.
 


### PR DESCRIPTION
Duplicated tags were making the documentation build to fail:

```
Error detected while processing command line:
E154: Duplicate tag ":HopLine" in file /nix/store/r01d6lradg4hcbp0a3bf3sbs0b5x6cy1-vimplugin-hop/share/vim-plugins/hop/doc/hop.txt
E154: Duplicate tag ":HopLineAC" in file /nix/store/r01d6lradg4hcbp0a3bf3sbs0b5x6cy1-vimplugin-hop/share/vim-plugins/hop/doc/hop.txt
E154: Duplicate tag ":HopLineBC" in file /nix/store/r01d6lradg4hcbp0a3bf3sbs0b5x6cy1-vimplugin-hop/share/vim-plugins/hop/doc/hop.txt
Failed to build help tags!
```