### PR TITLE
Fix duplicated vim help tags

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -129,9 +129,9 @@ the buffer before and after the cursor, respectively.
 
     This is akin to calling the |hop.hint_lines| Lua function.
 
-`:HopLineStart`                                                         *:HopLine*
-`:HopLineStartBC`                                                     *:HopLineBC*
-`:HopLineStartAC`                                                     *:HopLineAC*
+`:HopLineStart`                                                    *:HopLineStart*
+`:HopLineStartBC`                                                *:HopLineStartBC*
+`:HopLineStartAC`                                                *:HopLineStartAC*
     Like `HopLine` but skips leading whitespace on every line.
     Blank lines are skipped over.
 


### PR DESCRIPTION
This PR fixes the following error when install or update the plugin:

```
Error detected while processing /Users/kdoan/.config/nvim/init.lua:
line    1:
E5113: Error while calling lua chunk: .../share/nvim/site/pack/paqs/opt/paq-nvim/lua/paq-nvim.lua:58: Vim(helptags):E154: Duplicate tag ":HopLine" in file /Users/kdoan/.local/share/nvim/site/pack/paqs/start/hop.nvim/doc/hop.txt
Press ENTER or type command to continue
```

Related to https://github.com/phaazon/hop.nvim/pull/108