### PR TITLE
Fix duplicate helptags.

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -129,9 +129,9 @@ the buffer before and after the cursor, respectively.
 
     This is akin to calling the |hop.hint_lines| Lua function.
 
-`:HopLineStart`                                                         *:HopLine*
-`:HopLineStartBC`                                                     *:HopLineBC*
-`:HopLineStartAC`                                                     *:HopLineAC*
+`:HopLineStart`                                                         *:HopLineStart*
+`:HopLineStartBC`                                                     *:HopLineStartBC*
+`:HopLineStartAC`                                                     *:HopLineStartAC*
     Like `HopLine` but skips leading whitespace on every line.
     Blank lines are skipped over.
 


### PR DESCRIPTION
Duplicate tags cause errors when generating helptags. Additionally, it
makes the documentation for HopLineStart* commands harder to find.
