### PR TITLE
User can specify pattern to not be prompted with `hint_patterns`.

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -106,7 +106,8 @@ the buffer before and after the cursor, respectively.
 `:HopPatternAC`                                                    *:HopPatternAC*
     Ask the user for a pattern and hint the document with it.
 
-    This is akin to calling the |hop.hint_patterns| Lua function.
+    This is akin to calling the |hop.hint_patterns| Lua function
+    with no explicit pattern.
 
 `:HopChar1`                                                            *:HopChar1*
 `:HopChar1BC`                                                        *:HopChar1BC*
@@ -181,12 +182,13 @@ Most of the functions and values you need to know about are in `hop`.
     Arguments:~
         {opts}  Hop options.
 
-`hop.hint_patterns(`{opts}`)`                                    *hop.hint_patterns*
-    Annotate all patterns in the current window with key sequences after
-    having prompted the user for the pattern to search.
+`hop.hint_patterns(`{opts}`,` {pattern}`)`                         *hop.hint_patterns*
+    Annotate all matched patterns in the current window with key sequences.
 
     Arguments:~
-        {opts}  Hop options.
+        {opts}     Hop options.
+        {pattern}  (optional) The pattern to search for.
+                   If not set, the user is prompted for the pattern to search.
 
 `hop.hint_char1(`{opts}`)`                                          *hop.hint_char1*
     Let the user type a key and immediately hint all of its occurrences.

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -210,14 +210,19 @@ function M.hint_words(opts)
   hint_with(hint.by_word_start, get_command_opts(opts))
 end
 
-function M.hint_patterns(opts)
+function M.hint_patterns(opts, pattern)
   opts = get_command_opts(opts)
 
-  vim.fn.inputsave()
-  local ok, pat = pcall(vim.fn.input, 'Search: ')
-  vim.fn.inputrestore()
-
-  if not ok then return end
+  -- The pattern to search is either retrieved from the (optional) argument
+  -- or directly from user input.
+  if pattern then
+    pat = pattern
+  else
+    vim.fn.inputsave()
+    ok, pat = pcall(vim.fn.input, 'Search: ')
+    vim.fn.inputrestore()
+    if not ok then return end
+  end
 
   if #pat == 0 then
     eprintln('-> empty pattern', opts.teasing)


### PR DESCRIPTION
Well, this was even easier than the linestart thing :)
With this PR, my mapping now smoothly works with the following oneliner in my `.vimrc`:
```vimscript
nnoremap tD :lua require'hop'.hint_patterns({}, '\\d')<cr>
```