### PR TITLE
Fix doc tags

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -129,9 +129,9 @@ the buffer before and after the cursor, respectively.
 
     This is akin to calling the |hop.hint_lines| Lua function.
 
-`:HopLineStart`                                                         *:HopLine*
-`:HopLineStartBC`                                                     *:HopLineBC*
-`:HopLineStartAC`                                                     *:HopLineAC*
+`:HopLineStart`                                                    *:HopLineStart*
+`:HopLineStartBC`                                                *:HopLineStartBC*
+`:HopLineStartAC`                                                *:HopLineStartAC*
     Like `HopLine` but skips leading whitespace on every line.
     Blank lines are skipped over.
 


### PR DESCRIPTION
Noticed it was broken in https://github.com/NixOS/nixpkgs/pull/128723

```
  Building help tags
  Error detected while processing command line:
  E154: Duplicate tag ":HopLine" in file /nix/store/0k7yc0wk7s6w8y3d46lr3vbksq2nlnpy-vimplugin-hop-nvim-2021-06-27/share/vim-plugins/hop-nvim/doc/hop.txt
  E154: Duplicate tag ":HopLineAC" in file /nix/store/0k7yc0wk7s6w8y3d46lr3vbksq2nlnpy-vimplugin-hop-nvim-2021-06-27/share/vim-plugins/hop-nvim/doc/hop.txt
  E154: Duplicate tag ":HopLineBC" in file /nix/store/0k7yc0wk7s6w8y3d46lr3vbksq2nlnpy-vimplugin-hop-nvim-2021-06-27/share/vim-plugins/hop-nvim/doc/hop.txtFailed to build help tags!
```