### PR TITLE
Make hop.hint_word depend on iskeyword

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -94,7 +94,7 @@ the buffer before and after the cursor, respectively.
 `:HopWord`                                                              *:HopWord*
 `:HopWordBC`                                                          *:HopWordBC*
 `:HopWordAC`                                                          *:HopWordAC*
-    Annotate all words in the current window with key sequences. Typing a
+    Annotate all |word|s in the current window with key sequences. Typing a
     first  key will visually filter the sequences and reduce them. Continue
     typing key sequences until you reduce a sequence completely, which will
     bring your cursor at that position.

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -56,9 +56,10 @@ end
 
 -- Word hint mode.
 --
--- Used to tag words with hints.
--- M.by_word_start = M.by_searching('\\<\\w\\+')
-M.by_word_start = M.by_searching('\\w\\+')
+-- Used to tag words with hints, its behaviour depends on the
+-- iskeyword value.
+-- M.by_word_start = M.by_searching('\\<\\k\\+')
+M.by_word_start = M.by_searching('\\k\\+')
 
 -- Line hint mode.
 --


### PR DESCRIPTION
By using `\k`, which depends on the `iskeyword` value, `hop.hint_word` behaviour's becomes consistent with all the native words' commands, like `*` and `[i`.