### PR TITLE
Refactor to allow alternate hint strategies

### DIFF
--- a/lua/hop/constants.lua
+++ b/lua/hop/constants.lua
@@ -1,0 +1,8 @@
+local M = {}
+
+M.HintDirection = {
+  BEFORE_CURSOR = 1,
+  AFTER_CURSOR = 2,
+}
+
+return M

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -1,11 +1,7 @@
 local perm = require'hop.perm'
+local constants = require'hop.constants'
 
 local M = {}
-
-M.HintDirection = {
-  BEFORE_CURSOR = 1,
-  AFTER_CURSOR = 2,
-}
 
 -- I hate Lua.
 local function starts_with_uppercase(s)
@@ -132,11 +128,11 @@ function M.mark_hints_line(hint_mode, line_nr, line, col_offset, win_width, dire
   local col_bias = 0
   if direction_mode ~= nil then
     local col = vim.fn.byteidx(line, direction_mode.cursor_col + 1)
-    if direction_mode.direction == M.HintDirection.AFTER_CURSOR then
+    if direction_mode.direction == constants.HintDirection.AFTER_CURSOR then
       -- we want to change the start offset so that we ignore everything before the cursor
       shifted_line = shifted_line:sub(col - col_offset)
       col_bias = col - 1
-    elseif direction_mode.direction == M.HintDirection.BEFORE_CURSOR then
+    elseif direction_mode.direction == constants.HintDirection.BEFORE_CURSOR then
       -- we want to change the end
       shifted_line = shifted_line:sub(1, col - col_offset)
     end
@@ -254,7 +250,7 @@ function M.create_hints(hint_mode, win_width, cursor_pos, col_offset, top_line, 
   local hint_counts = 0
 
   -- in the case of a direction, we want to treat the first or last line (according to the direction) differently
-  if direction == M.HintDirection.AFTER_CURSOR then
+  if direction == constants.HintDirection.AFTER_CURSOR then
     -- the first line is to be checked first
     hint_counts = create_hints_for_line(
       1,
@@ -285,7 +281,7 @@ function M.create_hints(hint_mode, win_width, cursor_pos, col_offset, top_line, 
         lines
       )
     end
-  elseif direction == M.HintDirection.BEFORE_CURSOR then
+  elseif direction == constants.HintDirection.BEFORE_CURSOR then
     -- the last line is to be checked last
     for i = 1, #lines - 1 do
       hint_counts = create_hints_for_line(

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -123,9 +123,9 @@ end
 --
 -- The direction_mode argument allows to start / end hint creation after or before the cursor position
 --
--- This function returns the list of hints as well as the length of the line in the form of table:
+-- This function returns the list of hints in the form of table:
 --
---   { hints, length }
+--   { hints }
 function M.mark_hints_line(hint_mode, line_nr, line, col_offset, win_width, direction_mode)
   local hints = {}
   local end_index = nil
@@ -175,8 +175,7 @@ function M.mark_hints_line(hint_mode, line_nr, line, col_offset, win_width, dire
   end
 
   return {
-    hints = hints;
-    length = vim.fn.strdisplaywidth(shifted_line)
+    hints = hints
   }
 end
 
@@ -217,7 +216,7 @@ function M.reduce_hints_lines(per_line_hints, key)
       end
     end
 
-    output[#output + 1] = { hints = next_hints; length = hints.length }
+    output[#output + 1] = { hints = next_hints }
   end
 
   return nil, output, update_count

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -124,9 +124,7 @@ end
 --
 -- The direction_mode argument allows to start / end hint creation after or before the cursor position
 --
--- This function returns the list of hints in the form of table:
---
---   { hints }
+-- This function returns the list of hints
 function M.mark_hints_line(hint_mode, line_nr, line, col_offset, win_width, direction_mode)
   local hints = {}
   local end_index = nil

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -75,7 +75,7 @@ M.by_line_start = {
 --
 -- Used to tag the beginning of each lines with hints.
 function M.by_line_start_skip_whitespace()
-  pat = vim.regex("\\S")
+  local pat = vim.regex("\\S")
   return {
     oneshot = true,
     match = function(s)

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -25,6 +25,10 @@ function M.by_searching(pat, plain_search)
     oneshot = false,
     match = function(s)
       return vim.regex(pat):match_str(s)
+    end,
+
+    get_hints = function(self, opts)
+      return M.create_hints_by_scanning_lines(self, opts)
     end
   }
 end
@@ -47,6 +51,9 @@ function M.by_case_searching(pat, plain_search, opts)
     oneshot = false,
     match = function(s)
       return vim.regex(pat):match_str(s)
+    end,
+    get_hints = function(self, hint_opts)
+      return M.create_hints_by_scanning_lines(self, hint_opts)
     end
   }
 end
@@ -65,6 +72,9 @@ M.by_line_start = {
   oneshot = true,
   match = function(_)
     return 0, 1, false
+  end,
+  get_hints = function(self, hint_opts)
+    return M.create_hints_by_scanning_lines(self, hint_opts)
   end
 }
 
@@ -77,6 +87,9 @@ function M.by_line_start_skip_whitespace()
     oneshot = true,
     match = function(s)
       return pat:match_str(s)
+    end,
+    get_hints = function(self, hint_opts)
+      return M.create_hints_by_scanning_lines(self, hint_opts)
     end
   }
 end

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -215,10 +215,12 @@ function M.hint_patterns(opts, pattern)
 
   -- The pattern to search is either retrieved from the (optional) argument
   -- or directly from user input.
+  local pat
   if pattern then
     pat = pattern
   else
     vim.fn.inputsave()
+    local ok
     ok, pat = pcall(vim.fn.input, 'Search: ')
     vim.fn.inputrestore()
     if not ok then return end

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -87,6 +87,9 @@ local function hint_with(hint_mode, opts)
     return
   end
 
+  -- mutate hints to add character targets
+  hint.assign_character_targets(context, hints, opts)
+
   local hint_state = {
     hints = hints;
     hl_ns = hl_ns;

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -1,6 +1,7 @@
 local defaults = require'hop.defaults'
 local hint = require'hop.hint'
 local constants = require'hop.constants'
+local window = require'hop.window'
 
 local M = {}
 
@@ -54,54 +55,16 @@ end
 --
 -- The 'hint_mode' argument is the mode to use to hint the buffer.
 local function hint_with(hint_mode, opts)
-  -- get a bunch of information about the window and the cursor
-  local win_info = vim.fn.getwininfo(vim.api.nvim_get_current_win())[1]
-  local win_view = vim.fn.winsaveview()
-  local top_line = win_info.topline - 1
-  local bot_line = win_info.botline - 1
-  local cursor_pos = vim.api.nvim_win_get_cursor(0)
-
-  -- adjust the visible part of the buffer to hint based on the direction
-  local direction = opts.direction
-  local direction_mode = nil
-  if direction == hint.HintDirection.BEFORE_CURSOR then
-    bot_line = cursor_pos[1] - 1
-    direction_mode = { cursor_col = cursor_pos[2], direction = direction }
-  elseif direction == hint.HintDirection.AFTER_CURSOR then
-    top_line = cursor_pos[1] - 1
-    direction_mode = { cursor_col = cursor_pos[2], direction = direction }
-  end
-
-  -- NOTE: due to an (unknown yet) bug in neovim, the sign_width is not correctly reported when shifting the window
-  -- view inside a non-wrap window, so we can’t rely on this; for this reason, we have to implement a weird hack that
-  -- is going to disable the signs while hop is running (I’m sorry); the state is restored after jump
-  -- local left_col_offset = win_info.variables.context.number_width + win_info.variables.context.sign_width
-  local win_width = nil
-
-  -- hack to get the left column offset in nowrap
-  if not vim.wo.wrap then
-    vim.api.nvim_win_set_cursor(0, { cursor_pos[1], 0 })
-    local left_col_offset = vim.fn.wincol() - 1
-    vim.fn.winrestview(win_view)
-    win_width = win_info.width - left_col_offset
-  end
-
+  local context = window.get_window_context(opts.direction)
   -- create the highlight group and grey everything out; the highlight group will allow us to clean everything at once
   -- when hop quits
   local hl_ns = vim.api.nvim_create_namespace('')
-  grey_things_out(0, hl_ns, top_line, bot_line, direction_mode)
+  grey_things_out(0, hl_ns, context.top_line, context.bot_line, context.direction_mode)
 
   -- get the buffer lines and create hints; hint_counts allows us to display some error diagnostics to the user, if any,
   -- or even perform direct jump in the case of a single match
-  local win_lines = vim.api.nvim_buf_get_lines(0, top_line, bot_line + 1, false)
-  local hints, hint_counts = hint.create_hints(
+  local hints, hint_counts = hint.create_hints_by_scanning_lines(
     hint_mode,
-    win_width,
-    cursor_pos,
-    win_view.leftcol,
-    top_line,
-    win_lines,
-    direction,
     opts
   )
 
@@ -127,8 +90,8 @@ local function hint_with(hint_mode, opts)
   local hint_state = {
     hints = hints;
     hl_ns = hl_ns;
-    top_line = top_line;
-    bot_line = bot_line
+    top_line = context.top_line;
+    bot_line = context.bot_line
   }
 
   hint.set_hint_extmarks(hl_ns, hints)
@@ -155,7 +118,7 @@ local function hint_with(hint_mode, opts)
 
     if not_special_key and opts.keys:find(key, 1, true) then
       -- If this is a key used in hop (via opts.keys), deal with it in hop
-      h = M.refine_hints(0, key, opts.teasing, direction_mode, hint_state)
+      h = M.refine_hints(0, key, opts.teasing, context.direction_mode, hint_state)
       vim.cmd('redraw')
     else
       -- If it's not, quit hop

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -61,10 +61,9 @@ local function hint_with(hint_mode, opts)
   local hl_ns = vim.api.nvim_create_namespace('')
   grey_things_out(0, hl_ns, context.top_line, context.bot_line, context.direction_mode)
 
-  -- get the buffer lines and create hints; hint_counts allows us to display some error diagnostics to the user, if any,
-  -- or even perform direct jump in the case of a single match
-  local hints, hint_counts = hint.create_hints_by_scanning_lines(
-    hint_mode,
+  -- hint_counts allows us to display some error diagnostics to the user, if any, or even perform direct jump in the
+  -- case of a single match
+  local hints, hint_counts = hint_mode:get_hints(
     opts
   )
 

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -1,5 +1,6 @@
 local defaults = require'hop.defaults'
 local hint = require'hop.hint'
+local constants = require'hop.constants'
 
 local M = {}
 
@@ -31,12 +32,12 @@ local function grey_things_out(buf_handle, hl_ns, top_line, bottom_line, directi
   clear_namespace(buf_handle, hl_ns)
 
   if direction_mode ~= nil then
-    if direction_mode.direction == hint.HintDirection.AFTER_CURSOR then
+    if direction_mode.direction == constants.HintDirection.AFTER_CURSOR then
       vim.api.nvim_buf_add_highlight(buf_handle, hl_ns, 'HopUnmatched', top_line, direction_mode.cursor_col, -1)
       for line_i = top_line + 1, bottom_line do
         vim.api.nvim_buf_add_highlight(buf_handle, hl_ns, 'HopUnmatched', line_i, 0, -1)
       end
-    elseif direction_mode.direction == hint.HintDirection.BEFORE_CURSOR then
+    elseif direction_mode.direction == constants.HintDirection.BEFORE_CURSOR then
       for line_i = top_line, bottom_line - 1 do
         vim.api.nvim_buf_add_highlight(buf_handle, hl_ns, 'HopUnmatched', line_i, 0, -1)
       end

--- a/lua/hop/window.lua
+++ b/lua/hop/window.lua
@@ -1,0 +1,46 @@
+local constants = require'hop.constants'
+local M = {}
+
+function M.get_window_context(direction)
+  -- get a bunch of information about the window and the cursor
+  local win_info = vim.fn.getwininfo(vim.api.nvim_get_current_win())[1]
+  local win_view = vim.fn.winsaveview()
+  local top_line = win_info.topline - 1
+  local bot_line = win_info.botline - 1
+  local cursor_pos = vim.api.nvim_win_get_cursor(0)
+
+  -- adjust the visible part of the buffer to hint based on the direction
+  local direction_mode = nil
+  if direction == constants.HintDirection.BEFORE_CURSOR then
+    bot_line = cursor_pos[1] - 1
+    direction_mode = { cursor_col = cursor_pos[2], direction = direction }
+  elseif direction == constants.HintDirection.AFTER_CURSOR then
+    top_line = cursor_pos[1] - 1
+    direction_mode = { cursor_col = cursor_pos[2], direction = direction }
+  end
+
+  -- NOTE: due to an (unknown yet) bug in neovim, the sign_width is not correctly reported when shifting the window
+  -- view inside a non-wrap window, so we can’t rely on this; for this reason, we have to implement a weird hack that
+  -- is going to disable the signs while hop is running (I’m sorry); the state is restored after jump
+  -- local left_col_offset = win_info.variables.context.number_width + win_info.variables.context.sign_width
+  local win_width = nil
+
+  -- hack to get the left column offset in nowrap
+  if not vim.wo.wrap then
+    vim.api.nvim_win_set_cursor(0, { cursor_pos[1], 0 })
+    local left_col_offset = vim.fn.wincol() - 1
+    vim.fn.winrestview(win_view)
+    win_width = win_info.width - left_col_offset
+  end
+
+  return {
+    cursor_pos=cursor_pos,
+    top_line=top_line,
+    bot_line=bot_line,
+    direction_mode=direction_mode,
+    win_width=win_width,
+    col_offset=win_view.leftcol
+  }
+end
+
+return M

--- a/plugin/hop.vim
+++ b/plugin/hop.vim
@@ -7,30 +7,30 @@ endif
 
 " The jump-to-word command.
 command! HopWord lua require'hop'.hint_words()
-command! HopWordBC lua require'hop'.hint_words({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
-command! HopWordAC lua require'hop'.hint_words({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })
+command! HopWordBC lua require'hop'.hint_words({ direction = require'hop.constants'.HintDirection.BEFORE_CURSOR })
+command! HopWordAC lua require'hop'.hint_words({ direction = require'hop.constants'.HintDirection.AFTER_CURSOR })
 
 " The jump-to-pattern command.
 command! HopPattern lua require'hop'.hint_patterns()
-command! HopPatternBC lua require'hop'.hint_patterns({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
-command! HopPatternAC lua require'hop'.hint_patterns({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })
+command! HopPatternBC lua require'hop'.hint_patterns({ direction = require'hop.constants'.HintDirection.BEFORE_CURSOR })
+command! HopPatternAC lua require'hop'.hint_patterns({ direction = require'hop.constants'.HintDirection.AFTER_CURSOR })
 
 " The jump-to-char-1 command.
 command! HopChar1 lua require'hop'.hint_char1()
-command! HopChar1BC lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
-command! HopChar1AC lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })
+command! HopChar1BC lua require'hop'.hint_char1({ direction = require'hop.constants'.HintDirection.BEFORE_CURSOR })
+command! HopChar1AC lua require'hop'.hint_char1({ direction = require'hop.constants'.HintDirection.AFTER_CURSOR })
 
 " The jump-to-char-2 command.
 command! HopChar2 lua require'hop'.hint_char2()
-command! HopChar2BC lua require'hop'.hint_char2({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
-command! HopChar2AC lua require'hop'.hint_char2({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })
+command! HopChar2BC lua require'hop'.hint_char2({ direction = require'hop.constants'.HintDirection.BEFORE_CURSOR })
+command! HopChar2AC lua require'hop'.hint_char2({ direction = require'hop.constants'.HintDirection.AFTER_CURSOR })
 
 " The jump-to-line command.
 command! HopLine lua require'hop'.hint_lines()
-command! HopLineBC lua require'hop'.hint_lines({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
-command! HopLineAC lua require'hop'.hint_lines({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })
+command! HopLineBC lua require'hop'.hint_lines({ direction = require'hop.constants'.HintDirection.BEFORE_CURSOR })
+command! HopLineAC lua require'hop'.hint_lines({ direction = require'hop.constants'.HintDirection.AFTER_CURSOR })
 
 " The jump-to-line command.
 command! HopLineStart   lua require'hop'.hint_lines_skip_whitespace()
-command! HopLineStartBC lua require'hop'.hint_lines_skip_whitespace({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
-command! HopLineStartAC lua require'hop'.hint_lines_skip_whitespace({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })
+command! HopLineStartBC lua require'hop'.hint_lines_skip_whitespace({ direction = require'hop.constants'.HintDirection.BEFORE_CURSOR })
+command! HopLineStartAC lua require'hop'.hint_lines_skip_whitespace({ direction = require'hop.constants'.HintDirection.AFTER_CURSOR })


### PR DESCRIPTION
This PR should make it easier to modify hop to allow features like the ones mentioned in https://github.com/phaazon/hop.nvim/issues/116

Instead of each mode exposing a `match` function, and assuming that we will get hints by scanning the file one line at a time, the mode now exposes a `get_hint_list` function, which returns an array of `{line, col}` locations to jump.

TODO:
 - [ ] update documentation