### PR TITLE
Add current-line only motion.

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -1,4 +1,4 @@
-*hop.txt*    For Neovim version 0.5                  Last change: 2021 Feb 6
+*hop.txt*    For Neovim version 0.5                  Last change: 2021 Aug 19
 
                                  __
                                 / /_  ____  ____
@@ -137,6 +137,13 @@ the buffer before and after the cursor, respectively.
     Blank lines are skipped over.
 
     This is akin to calling the |hop.hint_lines_skip_whitespace| Lua function.
+
+`:HopChar1Line`                                                    *:HopLineStart*
+`:HopChar1LineBC`                                                *:HopLineStartBC*
+`:HopChar1LineAC`                                                *:HopLineStartAC*
+    Like `HopChar1` but its scope constrained to current line only.
+
+    This is akin to calling the |hop.hint_char1_line| Lua function.
 
                                                                    *hop-lua-api*
 Lua API~

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -54,6 +54,16 @@ function M.by_case_searching(pat, plain_search, opts)
   }
 end
 
+-- Current line hint mode
+--
+-- Used to constrain scope of hopping to current line only
+function M.by_case_searhing_line(pat, plain_search, opts)
+    local m = M.by_case_searching(pat, plain_search, opts)
+    m.curr_line_only = true
+
+    return m
+end
+
 -- Word hint mode.
 --
 -- Used to tag words with hints, its behaviour depends on the

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -71,6 +71,12 @@ local function hint_with(hint_mode, opts)
     direction_mode = { cursor_col = cursor_pos[2], direction = direction }
   end
 
+  -- Constrain range of lines if we are in current-line-only mode
+  if hint_mode.curr_line_only then
+    top_line = cursor_pos[1] - 1
+    bot_line = cursor_pos[1] - 1
+  end
+
   -- NOTE: due to an (unknown yet) bug in neovim, the sign_width is not correctly reported when shifting the window
   -- view inside a non-wrap window, so we can’t rely on this; for this reason, we have to implement a weird hack that
   -- is going to disable the signs while hop is running (I’m sorry); the state is restored after jump
@@ -237,6 +243,13 @@ function M.hint_char1(opts)
   local ok, c = pcall(vim.fn.getchar)
   if not ok then return end
   hint_with(hint.by_case_searching(vim.fn.nr2char(c), true, opts), opts)
+end
+
+function M.hint_char1_line(opts)
+    opts = get_command_opts(opts)
+    local ok, c = pcall(vim.fn.getchar)
+    if not ok then return end
+    hint_with(hint.by_case_searhing_line(vim.fn.nr2char(c), true, opts), opts)
 end
 
 function M.hint_char2(opts)

--- a/plugin/hop.vim
+++ b/plugin/hop.vim
@@ -34,3 +34,8 @@ command! HopLineAC lua require'hop'.hint_lines({ direction = require'hop.hint'.H
 command! HopLineStart   lua require'hop'.hint_lines_skip_whitespace()
 command! HopLineStartBC lua require'hop'.hint_lines_skip_whitespace({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
 command! HopLineStartAC lua require'hop'.hint_lines_skip_whitespace({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })
+
+" The jump-to-char-1 command constrained to current line
+command! HopChar1Line lua require'hop'.hint_char1_line()
+command! HopChar1LineAC lua require'hop'.hint_char1_line({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })
+command! HopChar1LineBC lua require'hop'.hint_char1_line({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })


### PR DESCRIPTION
- HopChar1Line will only grey out current line and perform the motion
  based on 1 character.
- This PR adds a new field to hint_mode table to track & preform this
  current-line only mode. I couldn't find a better way of doing it
  without doing rather big refactoring of the code base. And it seems
  #123 is stalled at the moment.
- Fixes #91 