### PR TITLE
Update jump list when jumping on sole occurrence

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -163,6 +163,11 @@ local function hint_with(hint_mode, opts)
     for _, line_hints in pairs(hints) do
       if #line_hints.hints == 1 then
         h = line_hints.hints[1]
+
+        -- prior to jump, register the current position into the jump list
+        vim.cmd("normal! m'")
+
+        -- JUMP!
         vim.api.nvim_win_set_cursor(0, { h.line + 1, h.col - 1})
         break
       end


### PR DESCRIPTION
Current position is not added to jump list when jumping on sole occurrence (when there is only one jump option available). This behavior is inconsistent with normal jumping since then jump list gets updated. This commit fixes this issue.