### PR TITLE
fix: only hide virtual text when hinting on Nvim 0.6

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -175,7 +175,7 @@ function M.hint_with_callback(jump_target_gtr, opts, callback)
   add_virt_cur(hl_ns)
   if vim.fn.has("nvim-0.6") == 1 then
     hint_state.diag_ns = vim.diagnostic.get_namespaces()
-    for ns in pairs(hint_state.diag_ns) do vim.diagnostic.hide(ns) end
+    for ns in pairs(hint_state.diag_ns) do vim.diagnostic.show(ns, 0, nil, { virt_text = false }) end
   end
   hint.set_hint_extmarks(hl_ns, hints)
   vim.cmd('redraw')


### PR DESCRIPTION
Avoid removing signs which possibly reflows buffer.

Also adapt to breaking change to diagnostics in https://github.com/neovim/neovim/pull/16323 (`nil` as second argument now means "all buffers").