### PR TITLE
Clamp column of the jump_target to the length of the line

### DIFF
--- a/lua/hop/jump_target.lua
+++ b/lua/hop/jump_target.lua
@@ -95,7 +95,7 @@ local function mark_jump_targets_line(regex, line_nr, line, col_offset, win_widt
     local colb = col + b
     jump_targets[#jump_targets + 1] = {
       line = line_nr,
-      column = math.max(1, colb + col_offset + col_bias),
+			column = math.min(math.max(1, colb + col_offset + col_bias), shifted_line:len()),
       window = 0,
     }
 


### PR DESCRIPTION
I am trying to make a HopLines but the column stays the same.
The easiest way seems to be:
```
opts = override_opts(opts)
local cursor_pos = vim.api.nvim_win_get_cursor(0)
local cursor_col = cursor_pos[2]
hint_with(
    jump_target.jump_targets_by_scanning_lines({
        oneshot = true,
        match = function()
            return cursor_col, cursor_col, false
        end,
    }),
    opts
)
```

The problem is if `cursor_col` is past the end of some other line. We
could either ignore it or clamp it to the end of the line.
Either way I cannot do it from the match function if I'm not wrong.
There is a pretty simple patch that seems to work to clamp it to
`shifted_line:len()`
