### PR TITLE
Add option 'jump_offset'

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ vim.api.nvim_set_keymap('n', 'f', "<cmd>lua require'hop'.hint_char1({ direction 
 vim.api.nvim_set_keymap('n', 'F', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR, current_line_only = true })<cr>", {})
 vim.api.nvim_set_keymap('o', 'f', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR, current_line_only = true, inclusive_jump = true })<cr>", {})
 vim.api.nvim_set_keymap('o', 'F', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR, current_line_only = true, inclusive_jump = true })<cr>", {})
-vim.api.nvim_set_keymap('', 't', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR, current_line_only = true })<cr>", {})
-vim.api.nvim_set_keymap('', 'T', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR, current_line_only = true })<cr>", {})
+vim.api.nvim_set_keymap('', 't', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR, current_line_only = true, jump_offset = -1 })<cr>", {})
+vim.api.nvim_set_keymap('', 'T', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR, current_line_only = true, jump_offset = 1 })<cr>", {})
 ```
 
 For a more complete user guide and help pages:

--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -676,6 +676,15 @@ below.
     Defaults:~
         `direction = nil`
 
+`jump_offset`                                            *hop-config-jump_offset*
+    If nonzero, once the jump is completed, the cursor will be offset
+    from the selected jump position by `jump_offset` characters.  This
+    is useful for emulating the normal motion commands |t| and |T| where
+    the cursor is positioned before/after the target position.
+
+    Defaults:~
+        `jump_offset = 0`
+
 `current_line_only`                                 *hop-config-current_line_only*
     Apply Hop commands only to the current line.
 

--- a/lua/hop/defaults.lua
+++ b/lua/hop/defaults.lua
@@ -11,5 +11,6 @@ M.create_hl_autocmd = true
 M.current_line_only = false
 M.inclusive_jump = false
 M.uppercase_labels = false
+M.jump_offset = 0
 
 return M

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -127,7 +127,7 @@ function M.hint_with(jump_target_gtr, opts)
   end
 
   M.hint_with_callback(jump_target_gtr, opts, function(jt)
-    M.move_cursor_to(jt.window, jt.line + 1, jt.column - 1, opts.inclusive_jump)
+    M.move_cursor_to(jt.window, jt.line + 1, jt.column - 1 + opts.jump_offset, opts.inclusive_jump)
   end)
 end
 


### PR DESCRIPTION
The vi motion commands |t| and |T| differ slightly from the |f| and |F|
motion commands since |t| and |T| position the cursor before/after
(respectively) relative to the target character.

Add an option 'jump_offset' that allows *hop* to faithfully emulate
this behavior.