### PR TITLE
Feature/cursor offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,15 +231,10 @@ If you want to create a key binding from within Lua:
 
 ```lua
 -- place this in one of your configuration file(s)
-vim.api.nvim_set_keymap('n', 'f', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR, current_line_only = true })<cr>", {})
-vim.api.nvim_set_keymap('n', 'F', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR, current_line_only = true })<cr>", {})
-vim.api.nvim_set_keymap('o', 'f', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR, current_line_only = true, inclusive_jump = true })<cr>", {})
-vim.api.nvim_set_keymap('o', 'F', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR, current_line_only = true, inclusive_jump = true })<cr>", {})
-vim.api.nvim_set_keymap('', 't', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR, current_line_only = true })<cr>", {})
-vim.api.nvim_set_keymap('', 'T', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR, current_line_only = true })<cr>", {})
-vim.api.nvim_set_keymap('n', '<leader>e', "<cmd> lua require'hop'.hint_words({ hint_position = require'hop.hint'.HintPosition.END })<cr>", {})
-vim.api.nvim_set_keymap('v', '<leader>e', "<cmd> lua require'hop'.hint_words({ hint_position = require'hop.hint'.HintPosition.END })<cr>", {})
-vim.api.nvim_set_keymap('o', '<leader>e', "<cmd> lua require'hop'.hint_words({ hint_position = require'hop.hint'.HintPosition.END, inclusive_jump = true })<cr>", {})
+vim.api.nvim_set_keymap('', 'f', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR, current_line_only = true })<cr>", {})
+vim.api.nvim_set_keymap('', 'F', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR, current_line_only = true })<cr>", {})
+vim.api.nvim_set_keymap('', 't', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR, current_line_only = true, hint_offset = -1 })<cr>", {})
+vim.api.nvim_set_keymap('', 'T', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR, current_line_only = true, hint_offset = 1 })<cr>", {})
 ```
 
 # Configuration

--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -728,6 +728,18 @@ below.
     Defaults:~
         `hint_position = require'hop.hint'.HintPosition.BEGIN`
 
+`hint_offset`                                             *hop-config-hint_offset*
+    Offset to apply to a jump location.
+
+    If it is non-zero, the jump target will be offset horizontally from the
+    selected jump position by `hint_offset` character(s).
+
+    This optino can be used for emulating the motion commands |t| and |T|  where
+    the cursor is positioned on/before the target position.
+
+    Defaults:~
+        `hint_offset = 0`
+
 `current_line_only`                                 *hop-config-current_line_only*
     Apply Hop commands only to the current line.
 

--- a/lua/hop/defaults.lua
+++ b/lua/hop/defaults.lua
@@ -13,5 +13,6 @@ M.inclusive_jump = false
 M.uppercase_labels = false
 M.multi_windows = false
 M.hint_position = require'hop.hint'.HintPosition.BEGIN
+M.hint_offset = 0
 
 return M


### PR DESCRIPTION
1. Add visual mode for `F`/ `f` keymap
2. Add offset option for the final position of cursor
3. Edit README keymap to emulate vim motion

Not sure if you would like to implement line offset afterward, so I used a table to wrap around offsets. 
I used the way you calculate offset in operation pending mode and removed `inclusive_jump`.
It might also be better to move default `F`/`f` offset to `HintDirection`.

