### PR TITLE
fix: don't rely on implicit nil->0 conversion in Neovim API

### DIFF
--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -94,7 +94,7 @@ function M.set_hint_extmarks(hl_ns, hints, opts)
     end
 
     if vim.fn.strdisplaywidth(label) == 1 then
-      vim.api.nvim_buf_set_extmark(hint.jump_target.buffer, hl_ns, hint.jump_target.line, hint.jump_target.column - 1, {
+      vim.api.nvim_buf_set_extmark(hint.jump_target.buffer or 0, hl_ns, hint.jump_target.line, hint.jump_target.column - 1, {
         virt_text = { { label, "HopNextKey" } },
         virt_text_pos = 'overlay',
         hl_mode = 'combine',
@@ -103,7 +103,7 @@ function M.set_hint_extmarks(hl_ns, hints, opts)
     else
       -- get the byte index of the second hint so that we can slice it correctly
       local snd_idx = vim.fn.byteidx(label, 1)
-      vim.api.nvim_buf_set_extmark(hint.jump_target.buffer, hl_ns, hint.jump_target.line, hint.jump_target.column - 1, { -- HERE
+      vim.api.nvim_buf_set_extmark(hint.jump_target.buffer or 0, hl_ns, hint.jump_target.line, hint.jump_target.column - 1, { -- HERE
         virt_text = { { label:sub(1, snd_idx), "HopNextKey1" }, { label:sub(snd_idx + 1), "HopNextKey2" } },
         virt_text_pos = 'overlay',
         hl_mode = 'combine',


### PR DESCRIPTION
Needed after https://github.com/neovim/neovim/issues/14090#issuecomment-1004318147

fixes #210 