### PR TITLE
Fix current_line_only bug.

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -693,6 +693,10 @@ below.
 `current_line_only`                                 *hop-config-current_line_only*
     Apply Hop commands only to the current line.
 
+    Note:
+        Trying to use this option along with |hop-config-multi_windows| is
+        unsound.
+
     Defaults:~
         `current_line_only = false`
 

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -6,8 +6,23 @@ local window = require'hop.window'
 
 local M = {}
 
+-- Ensure options are sound.
+--
+-- Some options cannot be used together. For instance, multi_windows and current_line_only don’t really make sense used
+-- together. This function will notify the user of such ill-formed configurations.
+local function check_opts(opts)
+  if not opts then
+    return
+  end
+
+  if opts.multi_windows and opts.current_line_only then
+    vim.notify('Cannot use current_line_only across multiple windows', 3)
+  end
+end
+
 -- Allows to override global options with user local overrides.
 local function override_opts(opts)
+  check_opts(opts)
   return setmetatable(opts or {}, {__index = M.opts})
 end
 
@@ -179,7 +194,7 @@ function M.hint_with_callback(jump_target_gtr, opts, callback)
   local buf_list = {}
   for _, bctx in ipairs(all_ctxs) do
     buf_list[#buf_list + 1] = bctx.hbuf
-    for _, wctx in ipairs(bctx) do
+    for _, wctx in ipairs(bctx.contexts) do
       window.clip_window_context(wctx, opts.direction)
       -- dim everything out, add the virtual cursor and hide diagnostics
       apply_dimming(bctx.hbuf, dim_ns, wctx.top_line, wctx.bot_line, wctx.cursor_pos, opts.direction, opts.current_line_only)

--- a/lua/hop/jump_target.lua
+++ b/lua/hop/jump_target.lua
@@ -179,7 +179,7 @@ function M.jump_targets_by_scanning_lines(regex)
     -- Iterate all buffers
     for _, bctx in ipairs(all_ctxs) do
       -- Iterate all windows of a same buffer
-      for _, wctx in ipairs(bctx) do
+      for _, wctx in ipairs(bctx.contexts) do
         window.clip_window_context(wctx, opts.direction)
         local lines = vim.api.nvim_buf_get_lines(bctx.hbuf, wctx.top_line, wctx.bot_line + 1, false)
 
@@ -281,7 +281,7 @@ end
 -- Jump target generator for regex applied only on the cursor line.
 function M.jump_targets_for_current_line(regex)
   return function(opts)
-    local context = window.get_window_context()
+    local context = window.get_window_context(false)[1].contexts[1]
     local line_n = context.cursor_pos[1]
     local line = vim.api.nvim_buf_get_lines(0, line_n - 1, line_n, false)
     local jump_targets = {}

--- a/lua/hop/window.lua
+++ b/lua/hop/window.lua
@@ -24,12 +24,12 @@ local function window_context(win_handle, cursor_pos)
   end
 
   return {
-    hwin=win_handle,
-    cursor_pos=cursor_pos,
-    top_line=top_line,
-    bot_line=bot_line,
-    win_width=win_width,
-    col_offset=win_view.leftcol
+    hwin = win_handle,
+    cursor_pos = cursor_pos,
+    top_line = top_line,
+    bot_line = bot_line,
+    win_width = win_width,
+    col_offset = win_view.leftcol
   }
 end
 
@@ -54,7 +54,7 @@ function M.get_window_context(multi_windows)
   local cur_hbuf = vim.api.nvim_win_get_buf(cur_hwin)
   all_ctxs[#all_ctxs + 1] = {
     hbuf = cur_hbuf,
-    window_context(cur_hwin, vim.api.nvim_win_get_cursor(cur_hwin)),
+    contexts = { window_context(cur_hwin, vim.api.nvim_win_get_cursor(cur_hwin)) },
   }
 
   if not multi_windows then
@@ -65,11 +65,12 @@ function M.get_window_context(multi_windows)
     local b = vim.api.nvim_win_get_buf(w)
     if w ~= cur_hwin then
 
-      -- Check duplicated buffers
+      -- check duplicated buffers; the way this is done is by accessing all the already known contexts and checking that
+      -- the buffer we are accessing is already present in; if it is, we then append the window context to that buffer
       local bctx = nil
-      for _, _bctx in ipairs(all_ctxs) do
-        if b == _bctx.hbuf then
-          bctx = _bctx
+      for _, buffer_ctx in ipairs(all_ctxs) do
+        if b == buffer_ctx.hbuf then
+          bctx = buffer_ctx.contexts
           break
         end
       end
@@ -79,7 +80,7 @@ function M.get_window_context(multi_windows)
       else
         all_ctxs[#all_ctxs + 1] = {
           hbuf = b,
-          window_context(w, vim.api.nvim_win_get_cursor(w))
+          contexts = { window_context(w, vim.api.nvim_win_get_cursor(w)) }
         }
       end
 


### PR DESCRIPTION
This was introduced in #205. The way window contexts are passed around
was altered (the get_window_context() function doesn’t return the
context immediately but now returns every contexts right away, unless a
flag is passed — multi_windows = false or nil).

Also, I realized why fixing that bug that opts.multi_windows and
opts.current_line_only are unsound used together. I don’t block the
behavior (yet? it’s weird) but I notify the user not to do that.

Fixes #214. Relates and probably fixes #213 as well.