### PR TITLE
fix: skip foldline's targets

### DIFF
--- a/lua/hop/jump_target.lua
+++ b/lua/hop/jump_target.lua
@@ -56,23 +56,23 @@ end
 -- Mark the current line with jump targets.
 --
 -- Returns the jump targets as described above.
-local function mark_jump_targets_line(buf_handle, win_handle, regex, line_nr, line, col_offset, win_width, direction_mode, hint_position)
+local function mark_jump_targets_line(buf_handle, win_handle, regex, line_context, col_offset, win_width, direction_mode, hint_position)
   local jump_targets = {}
   local end_index = nil
 
   if win_width ~= nil then
     end_index = col_offset + win_width
   else
-    end_index = vim.fn.strdisplaywidth(line)
+    end_index = vim.fn.strdisplaywidth(line_context.line)
   end
 
-  local shifted_line = line:sub(1 + col_offset, vim.fn.byteidx(line, end_index))
+  local shifted_line = line_context.line:sub(1 + col_offset, vim.fn.byteidx(line_context.line, end_index))
 
   -- modify the shifted line to take the direction mode into account, if any
   -- FIXME: we also need to do that for the cursor
   local col_bias = 0
   if direction_mode ~= nil then
-    local col = vim.fn.byteidx(line, direction_mode.cursor_col + 1)
+    local col = vim.fn.byteidx(line_context.line, direction_mode.cursor_col + 1)
     if direction_mode.direction == hint.HintDirection.AFTER_CURSOR then
       -- we want to change the start offset so that we ignore everything before the cursor
       shifted_line = shifted_line:sub(col - col_offset)
@@ -101,6 +101,8 @@ local function mark_jump_targets_line(buf_handle, win_handle, regex, line_nr, li
     jump_targets[#jump_targets + 1] = {
       line = line_nr,
       column = math.max(1, colp + col_offset + col_bias),
+      line = line_context.line_nr,
+      column = math.max(1, colp + col_offset + col_bias),
       buffer = buf_handle,
       window = win_handle,
     }
@@ -124,25 +126,22 @@ end
 local function create_jump_targets_for_line(
   buf_handle,
   win_handle,
-  i,
   jump_targets,
   indirect_jump_targets,
   regex,
-  top_line,
   col_offset,
   win_width,
   cursor_pos,
   direction_mode,
   hint_position,
-  lines
+  line_context
 )
   -- first, create the jump targets for the ith line
   local line_jump_targets = mark_jump_targets_line(
     buf_handle,
     win_handle,
     regex,
-    top_line + i - 1,
-    lines[i],
+    line_context,
     col_offset,
     win_width,
     direction_mode,
@@ -188,7 +187,8 @@ function M.jump_targets_by_scanning_lines(regex)
       -- Iterate all windows of a same buffer
       for _, wctx in ipairs(bctx.contexts) do
         window.clip_window_context(wctx, opts.direction)
-        local lines = vim.api.nvim_buf_get_lines(bctx.hbuf, wctx.top_line, wctx.bot_line + 1, false)
+        -- Get all lines' context
+        local lines = window.get_lines_context(bctx.hbuf, wctx)
 
         -- in the case of a direction, we want to treat the first or last line (according to the direction) differently
         if opts.direction == hint.HintDirection.AFTER_CURSOR then
@@ -196,34 +196,30 @@ function M.jump_targets_by_scanning_lines(regex)
           create_jump_targets_for_line(
             bctx.hbuf,
             wctx.hwin,
-            1,
             jump_targets,
             indirect_jump_targets,
             regex,
-            wctx.top_line,
             wctx.col_offset,
             wctx.win_width,
             wctx.cursor_pos,
             { cursor_col = wctx.cursor_pos[2], direction = opts.direction },
             opts.hint_position,
-            lines
+            lines[1]
           )
 
           for i = 2, #lines do
             create_jump_targets_for_line(
               bctx.hbuf,
               wctx.hwin,
-              i,
               jump_targets,
               indirect_jump_targets,
               regex,
-              wctx.top_line,
               wctx.col_offset,
               wctx.win_width,
               wctx.cursor_pos,
               nil,
               opts.hint_position,
-              lines
+              lines[i]
             )
           end
         elseif opts.direction == hint.HintDirection.BEFORE_CURSOR then
@@ -232,51 +228,45 @@ function M.jump_targets_by_scanning_lines(regex)
             create_jump_targets_for_line(
               bctx.hbuf,
               wctx.hwin,
-              i,
               jump_targets,
               indirect_jump_targets,
               regex,
-              wctx.top_line,
               wctx.col_offset,
               wctx.win_width,
               wctx.cursor_pos,
               nil,
               opts.hint_position,
-              lines
+              lines[i]
             )
           end
 
           create_jump_targets_for_line(
             bctx.hbuf,
             wctx.hwin,
-            #lines,
             jump_targets,
             indirect_jump_targets,
             regex,
-            wctx.top_line,
             wctx.col_offset,
             wctx.win_width,
             wctx.cursor_pos,
             { cursor_col = wctx.cursor_pos[2], direction = opts.direction },
             opts.hint_position,
-            lines
+            lines[#lines]
           )
         else
           for i = 1, #lines do
             create_jump_targets_for_line(
               bctx.hbuf,
               wctx.hwin,
-              i,
               jump_targets,
               indirect_jump_targets,
               regex,
-              wctx.top_line,
               wctx.col_offset,
               wctx.win_width,
               wctx.cursor_pos,
               nil,
               opts.hint_position,
-              lines
+              lines[i]
             )
           end
         end
@@ -302,17 +292,15 @@ function M.jump_targets_for_current_line(regex)
     create_jump_targets_for_line(
       0,
       0,
-      1,
       jump_targets,
       indirect_jump_targets,
       regex,
-      line_n - 1,
       context.col_offset,
       context.win_width,
       context.cursor_pos,
       { cursor_col = context.cursor_pos[2], direction = opts.direction },
       opts.hint_position,
-      line
+      { line_nr = line_n - 1, line = line[1] }
     )
 
     M.sort_indirect_jump_targets(indirect_jump_targets, opts)


### PR DESCRIPTION
Skip foldline's targets to avoid unneccessary regex match like the pictures showing below.

***Without this commit:***
![1](https://user-images.githubusercontent.com/17680752/153746550-77d90c89-5991-403e-a753-2d35f973bc64.png)

***With this commit***
![2](https://user-images.githubusercontent.com/17680752/153746584-f73a09ce-d898-40ba-9ef6-8230a56447eb.png)

(This commint is also important for the `match-mappings` feature of #133, which can avoid searching cost for regex match on large mappings)
