### PR TITLE
fix 'hint_anywhere' help tag

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -310,7 +310,7 @@ Most of the functions and values you need to know about are in `hop`.
     Arguments:~
         {opts}  Hop options.
 
-`hop.hint_anywhere(`{opts}`)`                                          *hop.hint_words*
+`hop.hint_anywhere(`{opts}`)`                                          *hop.hint_anywhere*
     Annotate anywhere in the current window with key sequences.
 
     Arguments:~


### PR DESCRIPTION
Thank you for your great plugin!

I noticed that "hop.hint_words" help tag is duplicated.
So it's very small PR, please review:pray: