### PR TITLE
doc: duplicate `hint_words` should be `hint_anywhere`

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -310,7 +310,7 @@ Most of the functions and values you need to know about are in `hop`.
     Arguments:~
         {opts}  Hop options.
 
-`hop.hint_anywhere(`{opts}`)`                                          *hop.hint_words*
+`hop.hint_anywhere(`{opts}`)`                                          *hop.hint_anywhere*
     Annotate anywhere in the current window with key sequences.
 
     Arguments:~


### PR DESCRIPTION
👋 Hey, when building `hop.nvim` I ran into an error:

```
E154: Duplicate tag "hop.hint_words" in file ./doc/hop.txtFailed to build help tags!
```

Looks like there was a typo with `hop.hint_words` and it should be `hop.hint_anywhere` to avoid the duplicatation.