### PR TITLE
Added new option to select hint position in match.

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ vim.api.nvim_set_keymap('o', 'f', "<cmd>lua require'hop'.hint_char1({ direction 
 vim.api.nvim_set_keymap('o', 'F', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR, current_line_only = true, inclusive_jump = true })<cr>", {})
 vim.api.nvim_set_keymap('', 't', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR, current_line_only = true })<cr>", {})
 vim.api.nvim_set_keymap('', 'T', "<cmd>lua require'hop'.hint_char1({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR, current_line_only = true })<cr>", {})
+vim.api.nvim_set_keymap('n', '<leader>e', "<cmd> lua require'hop'.hint_words({ hint_position = require'hop.hint'.HintPosition.END })<cr>", {})
+vim.api.nvim_set_keymap('v', '<leader>e', "<cmd> lua require'hop'.hint_words({ hint_position = require'hop.hint'.HintPosition.END })<cr>", {})
+vim.api.nvim_set_keymap('o', '<leader>e', "<cmd> lua require'hop'.hint_words({ hint_position = require'hop.hint'.HintPosition.END, inclusive_jump = true })<cr>", {})
 ```
 
 # Configuration

--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -318,7 +318,7 @@ Most of the functions and values you need to know about are in `hop`.
 
 Hint API~
 
-The hint API provide the `HintDirection`
+The hint API provide the `HintDirection` and `HintPosition`
 
 `hop.hint.HintDirection`                                  *hop.hint.HintDirection*
     Enumeration for hinting direction.
@@ -329,6 +329,17 @@ The hint API provide the `HintDirection`
     Enumeration variants:~
         {BEFORE_CURSOR} Create and apply hints before the cursor.
         {AFTER_CURSOR}  Create and apply hints after the cursor.
+
+`hop.hint.HintPosition`                                    *hop.hint.HintPosition*
+    Enumeration for hinting position in match.
+
+    Use this table as a value for |hop-config-hint_posititon|.
+
+    Enumeration variants:~
+        {BEGIN}  Create and apply hints at the beginning of the match.
+        {MIDDLE} Create and apply hints at the middle of the match.
+        {END}    Create and apply hints at the end of the match.
+
                                                            *hop-jump-target-api*
 Jump target API~
 
@@ -709,6 +720,13 @@ below.
 
     Defaults:~
         `direction = nil`
+
+`hint_position`                                         *hop-config-hint_position*
+    Position of hint in match. See |hop.hint.HintPosition| for further
+    details.
+
+    Defaults:~
+        `hint_position = require'hop.hint'.HintPosition.BEGIN`
 
 `current_line_only`                                 *hop-config-current_line_only*
     Apply Hop commands only to the current line.

--- a/lua/hop/defaults.lua
+++ b/lua/hop/defaults.lua
@@ -12,5 +12,6 @@ M.current_line_only = false
 M.inclusive_jump = false
 M.uppercase_labels = false
 M.multi_windows = false
+M.hint_position = require'hop.hint'.HintPosition.BEGIN
 
 return M

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -8,6 +8,12 @@ M.HintDirection = {
   AFTER_CURSOR = 2,
 }
 
+M.HintPosition = {
+  BEGIN = 1,
+  MIDDLE = 2,
+  END = 3,
+}
+
 local function tbl_to_str(label)
   local s = ''
 

--- a/lua/hop/jump_target.lua
+++ b/lua/hop/jump_target.lua
@@ -56,7 +56,7 @@ end
 -- Mark the current line with jump targets.
 --
 -- Returns the jump targets as described above.
-local function mark_jump_targets_line(buf_handle, win_handle, regex, line_nr, line, col_offset, win_width, direction_mode)
+local function mark_jump_targets_line(buf_handle, win_handle, regex, line_nr, line, col_offset, win_width, direction_mode, hint_position)
   local jump_targets = {}
   local end_index = nil
 
@@ -92,10 +92,15 @@ local function mark_jump_targets_line(buf_handle, win_handle, regex, line_nr, li
       break
     end
 
-    local colb = col + b
+    local colp = col + b
+    if hint_position == hint.HintPosition.MIDDLE then
+      colp = col + math.floor((b + e) / 2)
+    elseif hint_position == hint.HintPosition.END then
+      colp = col + e - 1
+    end
     jump_targets[#jump_targets + 1] = {
       line = line_nr,
-      column = math.max(1, colb + col_offset + col_bias),
+      column = math.max(1, colp + col_offset + col_bias),
       buffer = buf_handle,
       window = win_handle,
     }
@@ -128,6 +133,7 @@ local function create_jump_targets_for_line(
   win_width,
   cursor_pos,
   direction_mode,
+  hint_position,
   lines
 )
   -- first, create the jump targets for the ith line
@@ -139,7 +145,8 @@ local function create_jump_targets_for_line(
     lines[i],
     col_offset,
     win_width,
-    direction_mode
+    direction_mode,
+    hint_position
   )
 
   -- then, append those to the input jump target list and create the indexed jump targets
@@ -198,6 +205,7 @@ function M.jump_targets_by_scanning_lines(regex)
             wctx.win_width,
             wctx.cursor_pos,
             { cursor_col = wctx.cursor_pos[2], direction = opts.direction },
+            opts.hint_position,
             lines
           )
 
@@ -214,6 +222,7 @@ function M.jump_targets_by_scanning_lines(regex)
               wctx.win_width,
               wctx.cursor_pos,
               nil,
+              opts.hint_position,
               lines
             )
           end
@@ -232,6 +241,7 @@ function M.jump_targets_by_scanning_lines(regex)
               wctx.win_width,
               wctx.cursor_pos,
               nil,
+              opts.hint_position,
               lines
             )
           end
@@ -248,6 +258,7 @@ function M.jump_targets_by_scanning_lines(regex)
             wctx.win_width,
             wctx.cursor_pos,
             { cursor_col = wctx.cursor_pos[2], direction = opts.direction },
+            opts.hint_position,
             lines
           )
         else
@@ -264,6 +275,7 @@ function M.jump_targets_by_scanning_lines(regex)
               wctx.win_width,
               wctx.cursor_pos,
               nil,
+              opts.hint_position,
               lines
             )
           end
@@ -299,6 +311,7 @@ function M.jump_targets_for_current_line(regex)
       context.win_width,
       context.cursor_pos,
       { cursor_col = context.cursor_pos[2], direction = opts.direction },
+      opts.hint_position,
       line
     )
 


### PR DESCRIPTION
For example, now you can use this command to hint word endings:

```lua
:lua require"hop".hint_words({hint_position = require"hop.hint".HintPosition.END})
```

Found discussion near this feature in this thread https://github.com/phaazon/hop.nvim/issues/71#issuecomment-1016617327