### PR TITLE
fix(health): update to upstream changes

### DIFF
--- a/lua/hop/health.lua
+++ b/lua/hop/health.lua
@@ -5,7 +5,7 @@ local hop = require'hop'
 --
 -- This function will perform checks at initialization to ensure everything will work as expected.
 function M.check()
-  local health = require'health'
+  local health = vim.health or require'health'
 
   health.report_start('Ensuring keys are unique')
   local existing_keys = {}


### PR DESCRIPTION
The `health` module was moved to `vim.health` in https://github.com/neovim/neovim/pull/18720