### PR TITLE
Fix BEFORE_CURSOR virtual edit.

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -69,13 +69,25 @@ local function apply_dimming(buf_handle, hl_ns, top_line, bottom_line, cursor_po
       end_line = cursor_pos[1]
     end
   end
+
   local extmark_options = {
     end_line = end_line,
     hl_group = 'HopUnmatched',
     hl_eol = true,
     priority = prio.DIM_PRIO
   }
-  if end_col then extmark_options.end_col = end_col end
+
+  if end_col then
+    local current_line = vim.api.nvim_buf_get_lines(buf_handle, cursor_pos[1] - 1, cursor_pos[1], true)[1]
+    local current_width = vim.fn.strdisplaywidth(current_line)
+
+    if end_col > current_width then
+      end_col = current_width - 1
+    end
+
+    extmark_options.end_col = end_col
+  end
+
   vim.api.nvim_buf_set_extmark(buf_handle, hl_ns, start_line, start_col,
                                extmark_options)
 end


### PR DESCRIPTION
We computed the dimming wrong because we were trying to set an extmark
in place in the buffer that doesn’t exist (the place where the
virtualedit + 1 column takes effect).