### PR TITLE
Feature/HopLinesPosition

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -514,6 +514,26 @@ function M.hint_lines(opts)
   )
 end
 
+function M.hint_lines_position(opts)
+  opts = override_opts(opts)
+  -- only makes sense as end position given movement goal.
+  opts.hint_position = require'hop.hint'.HintPosition.END 
+
+  local generator
+  if opts.current_line_only then
+    generator = jump_target.jump_targets_for_current_line
+  else
+    generator = jump_target.jump_targets_by_scanning_lines
+  end
+
+  -- FIXME: need to exclude current and include empty lines.
+  M.hint_with(
+    generator(jump_target.regex_by_line_position()),
+    opts
+  )
+end
+
+
 function M.hint_lines_skip_whitespace(opts)
   opts = override_opts(opts)
 

--- a/lua/hop/jump_target.lua
+++ b/lua/hop/jump_target.lua
@@ -393,6 +393,18 @@ function M.regex_by_line_start()
   }
 end
 
+-- Line regex at cursor position.
+function M.regex_by_line_position()
+  local position = vim.api.nvim_win_get_cursor(0)[2]
+  local pattern = vim.regex(string.format("^.\\{0,%d\\}\\(.\\|$\\)", position))
+  return {
+    oneshot = true,
+    match = function(s)
+      return pattern:match_str(s)
+    end
+  }
+end
+
 -- Line regex skipping finding the first non-whitespace character on each line.
 function M.regex_by_line_start_skip_whitespace()
   local pat = vim.regex("\\S")

--- a/plugin/hop.vim
+++ b/plugin/hop.vim
@@ -48,6 +48,12 @@ command! HopLineAC lua require'hop'.hint_lines({ direction = require'hop.hint'.H
 command! HopLineMW lua require'hop'.hint_lines({ multi_windows = true })
 
 " The jump-to-line command.
+command! HopLinePosition   lua require'hop'.hint_lines_position()
+command! HopLinePositionBC lua require'hop'.hint_lines_position({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
+command! HopLinePositionAC lua require'hop'.hint_lines_position({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })
+command! HopLinePositionMW lua require'hop'.hint_lines_position({ multi_windows = true })
+
+" The jump-to-line command.
 command! HopLineStart   lua require'hop'.hint_lines_skip_whitespace()
 command! HopLineStartBC lua require'hop'.hint_lines_skip_whitespace({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
 command! HopLineStartAC lua require'hop'.hint_lines_skip_whitespace({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })


### PR DESCRIPTION
As per https://github.com/phaazon/hop.nvim/issues/251, I implemented line movement commands which maintain the current cursor position.

There are two current issues that I see:

1. Hop's line related functions currently ignore empty lines.
    - There are many instances where I would want to move to a blank line, so this should not be the default.
3. Those same functions also include the source line in the hint suggestions.
    - This is not very useful in this context.

Both of these issues seem to arise from the way the `jump_targets_by_scanning_lines` function works.
I'm not sure of the best way to implement that functionality (e.g., providing option flags, or as a separate function), so that would be best implemented as another feature.
