### PR TITLE
get_window_context: use new nvim api for !multi_window as well

### DIFF
--- a/lua/hop/window.lua
+++ b/lua/hop/window.lua
@@ -55,7 +55,7 @@ function M.get_window_context(multi_windows)
   local cur_hbuf = vim.api.nvim_win_get_buf(cur_hwin)
   all_ctxs[#all_ctxs + 1] = {
     hbuf = cur_hbuf,
-    contexts = { window_context(cur_hwin, {vim.fn.getcurpos()[2], vim.fn.getcurpos()[5]} ) },
+    contexts = { window_context(cur_hwin, vim.api.nvim_win_get_cursor(cur_hwin)) },
   }
 
   if not multi_windows then


### PR DESCRIPTION
Otherwise you'll get this error if you use a command with direction on an empty line.
![image](https://user-images.githubusercontent.com/13046595/175557511-b86e37d1-c0e7-4cbf-a582-88d8789d9fed.png)

It happens because old api returns 'wrong' column in some cases (eg when $ it sets just a big number) & it doesn't understand empty lines...