### PR TITLE
fix: pending operation col increment

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -256,20 +256,20 @@ end
 -- Add option to shift cursor by column offset
 --
 -- This function will update the jump list.
-function M.move_cursor_to(w, line, column, hint_offset)
+function M.move_cursor_to(w, line, column, hint_offset, direction)
   -- If we do not ask for an offset jump, we don’t have to retrieve any additional lines because we will jump to the
   -- actual jump target. If we do want a jump with an offset, we need to retrieve the line the jump target lies in so
   -- that we can compute the offset correctly. This is linked to the fact that currently, Neovim doesn’s have an API to
   -- « offset something by N visual columns. »
+
+  -- If it is pending for operator shift column to the right by 1
+  if vim.api.nvim_get_mode().mode == 'no' and direction ~= 1 then
+    column = column + 1
+  end
+
   if hint_offset ~= nil and not (hint_offset == 0) then
     column = column + hint_offset
     local buf_line = vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(w), line - 1, line, false)[1]
-
-    -- If it is pending for operator shift column to the right by 1
-    -- if vim.api.nvim_get_mode().mode == 'no' then
-    --   column = column + 1
-    -- end
-
     column = vim.fn.byteidx(buf_line, column)
   end
 
@@ -285,7 +285,7 @@ function M.hint_with(jump_target_gtr, opts)
   end
 
   M.hint_with_callback(jump_target_gtr, opts, function(jt)
-    M.move_cursor_to(jt.window, jt.line + 1, jt.column - 1, opts.hint_offset)
+    M.move_cursor_to(jt.window, jt.line + 1, jt.column - 1, opts.hint_offset, opts.direction)
   end)
 end
 

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -266,9 +266,9 @@ function M.move_cursor_to(w, line, column, hint_offset)
     local buf_line = vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(w), line - 1, line, false)[1]
 
     -- If it is pending for operator shift column to the right by 1
-    if vim.api.nvim_get_mode().mode == 'no' then
-      column = column + 1
-    end
+    -- if vim.api.nvim_get_mode().mode == 'no' then
+    --   column = column + 1
+    -- end
 
     column = vim.fn.byteidx(buf_line, column)
   end


### PR DESCRIPTION
I think this is the desired behavior for any pending operation destination

Jumping backwards seems to already works fine (it leaves out the character you jump from but that is already how vim works)
Jumping forwards needs to be incremented if done from a pending operation context
