### PR TITLE
fix: fix "col value outside range" error

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -93,7 +93,7 @@ local function set_unmatched_lines(buf_handle, hl_ns, top_line, bottom_line, cur
     start_col = cursor_pos[2]
   elseif direction == hint.HintDirection.BEFORE_CURSOR then
     end_line = bottom_line - 1
-    if cursor_pos[2] ~= 0 then end_col = cursor_pos[2] + 1 end
+    if cursor_pos[2] ~= 0 then end_col = cursor_pos[2] end
   end
 
   if current_line_only then

--- a/lua/hop/window.lua
+++ b/lua/hop/window.lua
@@ -53,9 +53,11 @@ function M.get_window_context(multi_windows)
   -- Generate contexts of windows
   local cur_hwin = vim.api.nvim_get_current_win()
   local cur_hbuf = vim.api.nvim_win_get_buf(cur_hwin)
+  local cur_col = vim.fn.strwidth(vim.api.nvim_get_current_line():sub(1, vim.fn.col('.')))
+
   all_ctxs[#all_ctxs + 1] = {
     hbuf = cur_hbuf,
-    contexts = { window_context(cur_hwin, {vim.fn.getcurpos()[2], vim.fn.getcurpos()[5]} ) },
+    contexts = { window_context(cur_hwin, {vim.fn.line('.'), cur_col} ) },
   }
 
   if not multi_windows then


### PR DESCRIPTION
getcurpos()'s curswant refers to the _preferred_ column, and it
signifies to what column the cursor should get back to after moving over
empty or shorter lines. It does not refer to the actual cursor position,
and cannot be used here because it can report a column that does not
actually exist on the current line.

virtcol() would be more correct, as it reports the actual column.
However, it counts hard tabs as their screen width, could still cause
out of range errors.

Instead get the current line up to the cursor and calculate the column
with strwidth().

Fixes #261 #267