### PR TITLE
fix: make ctrl-c equivalent to esc in :HopPattern prompt

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -216,7 +216,10 @@ local function get_input_pattern(prompt, maxchar, opts)
     vim.api.nvim_echo({{prompt, 'Question'}, {pat}}, false, {})
 
     local ok, key = pcall(vim.fn.getchar)
-    if not ok then break end -- Interrupted by <C-c>
+    if not ok then -- Interrupted by <C-c>
+      pat = nil
+      break
+    end
 
     if type(key) == 'number' then
       key = vim.fn.nr2char(key)


### PR DESCRIPTION
Pressing CTRL-C was not properly aborting :HopPattern, because it still
returned some pattern from the function. Make it equivalent to CR.