### PR TITLE
Add new commands for hopping to the end of words

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -422,6 +422,22 @@ function M.hint_words(opts)
   )
 end
 
+function M.hint_word_ends(opts)
+  opts = override_opts(opts)
+
+  local generator
+  if opts.current_line_only then
+    generator = jump_target.jump_targets_for_current_line
+  else
+    generator = jump_target.jump_targets_by_scanning_lines
+  end
+
+  M.hint_with(
+    generator(jump_target.regex_by_word_end()),
+    opts
+  )
+end
+
 function M.hint_patterns(opts, pattern)
   opts = override_opts(opts)
 

--- a/lua/hop/jump_target.lua
+++ b/lua/hop/jump_target.lua
@@ -383,6 +383,11 @@ function M.regex_by_word_start()
   return M.regex_by_searching('\\k\\+')
 end
 
+-- Word end regex.
+function M.regex_by_word_end()
+  return M.regex_by_searching('\\k\\(\\W\\|$\\)')
+end
+
 -- Line regex.
 function M.regex_by_line_start()
   return {

--- a/plugin/hop.vim
+++ b/plugin/hop.vim
@@ -14,6 +14,15 @@ command! HopWordCurrentLineBC lua require'hop'.hint_words({ direction = require'
 command! HopWordCurrentLineAC lua require'hop'.hint_words({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR, current_line_only = true })
 command! HopWordMW            lua require'hop'.hint_words({ multi_windows = true })
 
+" The jump-to-word-end command.
+command! HopWordEnd              lua require'hop'.hint_word_ends()
+command! HopWordEndBC            lua require'hop'.hint_word_ends({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })
+command! HopWordEndAC            lua require'hop'.hint_word_ends({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR })
+command! HopWordEndCurrentLine   lua require'hop'.hint_word_ends({ current_line_only = true })
+command! HopWordEndCurrentLineBC lua require'hop'.hint_word_ends({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR, current_line_only = true })
+command! HopWordEndCurrentLineAC lua require'hop'.hint_word_ends({ direction = require'hop.hint'.HintDirection.AFTER_CURSOR, current_line_only = true })
+command! HopWordEndMW            lua require'hop'.hint_word_ends({ multi_windows = true })
+
 " The jump-to-pattern command.
 command! HopPattern              lua require'hop'.hint_patterns()
 command! HopPatternBC            lua require'hop'.hint_patterns({ direction = require'hop.hint'.HintDirection.BEFORE_CURSOR })


### PR DESCRIPTION
I've implemented word movement commands which allow you to hop to the end of words.
This was raised here: #260.

Preview of the implemented feature:
<img width="469" alt="Screen Shot 2022-07-10 at 11 10 08" src="https://user-images.githubusercontent.com/33261592/178132707-2301eaeb-596b-4eb6-ba42-6efecb64575e.png">

