### PR TITLE
Fix quitting in MW when a float is present.

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -405,7 +405,10 @@ function M.quit(hint_state)
   clear_namespace(hint_state.buf_list, hint_state.dim_ns)
 
   for _, buf in ipairs(hint_state.buf_list) do
-    if vim.fn.has("nvim-0.6") == 1 then
+    -- sometimes, buffers might be unloaded; that’s the case with floats for instance (we can invoke Hop from them but
+    -- then they disappear); we need to check whether the buffer is still valid before trying to do anything else with
+    -- it
+    if vim.api.nvim_buf_is_valid(buf) and vim.fn.has("nvim-0.6") == 1 then
       for ns in pairs(hint_state.diag_ns) do vim.diagnostic.show(ns, buf) end
     end
   end


### PR DESCRIPTION
Some buffers will be unloaded, and we need to check that when quitting. That commit fixes that issue, which is not strictly #278 but very similar.

We might not something else to completely fix their problem but that was a bug for sure hiding in the shadows.