### PR TITLE
Fix broken matching when magic chars are included in opts.keys.

### DIFF
--- a/lua/hop/perm.lua
+++ b/lua/hop/perm.lua
@@ -7,7 +7,7 @@ end
 
 -- Get the next key of the input key in the input key set, if any, or return nil.
 local function next_key(keys, key)
-  local _, e = keys:find(key)
+  local _, e = keys:find(key, 1, true)
 
   if e == #keys then
     return nil


### PR DESCRIPTION
Closes #263.

(Sorry for the mess in the linked issue. I didn't know GitHub notifies all pushes like this. It won't happen again.)