### PR TITLE
Fix incorrect behavior in multi-byte chars

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -273,9 +273,12 @@ function M.move_cursor_to(w, line, column, hint_offset, direction)
   end
 
   if hint_offset ~= nil and not (hint_offset == 0) then
-    column = column + hint_offset
+    -- Add `hint_offset` based on `charidx`.
     local buf_line = vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(w), line - 1, line, false)[1]
-    column = vim.fn.byteidx(buf_line, column)
+    -- Since `charidx` returns -1 when `column` is the tail, subtract 1 and add 1 to the return value to get
+    -- the correct value.
+    local char_idx = vim.fn.charidx(buf_line, column - 1) + 1 + hint_offset
+    column = vim.fn.byteidx(buf_line, char_idx)
   end
 
   -- update the jump list

--- a/lua/hop/window.lua
+++ b/lua/hop/window.lua
@@ -53,11 +53,10 @@ function M.get_window_context(multi_windows)
   -- Generate contexts of windows
   local cur_hwin = vim.api.nvim_get_current_win()
   local cur_hbuf = vim.api.nvim_win_get_buf(cur_hwin)
-  local cur_col = vim.fn.strwidth(vim.api.nvim_get_current_line():sub(1, vim.fn.col('.')))
 
   all_ctxs[#all_ctxs + 1] = {
     hbuf = cur_hbuf,
-    contexts = { window_context(cur_hwin, {vim.fn.line('.'), cur_col} ) },
+    contexts = { window_context(cur_hwin, {vim.fn.line('.'), vim.fn.charcol('.')} ) },
   }
 
   if not multi_windows then


### PR DESCRIPTION
This PR fixes these incorrect behavior.

---

`:HopChar1AC` with `a` shows a hint on the 1st char:
```
ああ*あaaa
```

---

`:lua require'hop'.hint_char1 { direction = require'hop.hint'.HintDirection.BEFORE_CURSOR, hint_offset = -1 }` with `a` and select 1st `a` raises the error `Column value outside range`:
```
aaaあ*ああ
```