### PR TITLE
Fix column out of range for HopLine*.

### DIFF
--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -99,8 +99,10 @@ function M.set_hint_extmarks(hl_ns, hints, opts)
       label = label:upper()
     end
 
+    local col = hint.jump_target.column - 1
+
     if vim.fn.strdisplaywidth(label) == 1 then
-      vim.api.nvim_buf_set_extmark(hint.jump_target.buffer or 0, hl_ns, hint.jump_target.line, hint.jump_target.column - 1, {
+      vim.api.nvim_buf_set_extmark(hint.jump_target.buffer or 0, hl_ns, hint.jump_target.line, col, {
         virt_text = { { label, "HopNextKey" } },
         virt_text_pos = 'overlay',
         hl_mode = 'combine',
@@ -109,7 +111,7 @@ function M.set_hint_extmarks(hl_ns, hints, opts)
     else
       -- get the byte index of the second hint so that we can slice it correctly
       local snd_idx = vim.fn.byteidx(label, 1)
-      vim.api.nvim_buf_set_extmark(hint.jump_target.buffer or 0, hl_ns, hint.jump_target.line, hint.jump_target.column - 1, { -- HERE
+      vim.api.nvim_buf_set_extmark(hint.jump_target.buffer or 0, hl_ns, hint.jump_target.line, col, {
         virt_text = { { label:sub(1, snd_idx), "HopNextKey1" }, { label:sub(snd_idx + 1), "HopNextKey2" } },
         virt_text_pos = 'overlay',
         hl_mode = 'combine',

--- a/lua/hop/jump_target.lua
+++ b/lua/hop/jump_target.lua
@@ -385,10 +385,17 @@ end
 
 -- Line regex.
 function M.regex_by_line_start()
+  local c = vim.fn.winsaveview().leftcol
+
   return {
     oneshot = true,
-    match = function(_)
-      return 0, 1, false
+    match = function(s)
+      local l = vim.fn.strdisplaywidth(s)
+      if c > 0 and l == 0 then
+        return nil
+      end
+
+      return 0, 1
     end
   }
 end


### PR DESCRIPTION
This commit has the disavantage of preventing people from jumping to empty lines if they have shifted their view. However, I think it’s okay because we cannot place a hint in a buffer that is not visible, unless we start hacking around with the text_column thing, and I don’t think it’s worth it for now.

Fixes #292.