### PR TITLE
made plugin/hop.vim respect g:loaded_hop

### DIFF
--- a/plugin/hop.vim
+++ b/plugin/hop.vim
@@ -1,3 +1,8 @@
+if exists('g:loaded_hop')
+  finish
+endif
+let g:loaded_hop = 1
+
 if !has('nvim-0.5.0')
   echohl Error
   echom 'This plugin only works with Neovim >= v0.5.0'


### PR DESCRIPTION
according to the `:h write-plugin`, this `has(g:loaded_xx)` gives user a chance to not load plugin/hop.vim.

well, i personally dont need so many user commands