### PR TITLE
Replace charcol that is only supported in neovim 0.7

### DIFF
--- a/lua/hop/window.lua
+++ b/lua/hop/window.lua
@@ -53,10 +53,11 @@ function M.get_window_context(multi_windows)
   -- Generate contexts of windows
   local cur_hwin = vim.api.nvim_get_current_win()
   local cur_hbuf = vim.api.nvim_win_get_buf(cur_hwin)
+  local cur_col = vim.fn.strwidth(vim.api.nvim_get_current_line():sub(1, vim.fn.col('.')))
 
   all_ctxs[#all_ctxs + 1] = {
     hbuf = cur_hbuf,
-    contexts = { window_context(cur_hwin, {vim.fn.line('.'), vim.fn.charcol('.')} ) },
+    contexts = { window_context(cur_hwin, {vim.fn.line('.'), cur_col} ) },
   }
 
   if not multi_windows then


### PR DESCRIPTION
This commit replaces Neovim's built-in function charcol with functions that is available >= 0.5. 
charcoal Neovim built-in function is introduced in Neovim 0.7 (see https://github.com/neovim/neovim/commit/6ab71683d14a408e79f7cbda3a07ab65f76c6b35). The get_window_context function in hop.nvim will raise function not found error when the Neovim version is below 0.7. 
This commit partially reverts the 6ed29f1 commit without breaking it. 
