### PR TITLE
Fix regression of #267 (Error: col val outside range)

### DIFF
--- a/lua/hop/window.lua
+++ b/lua/hop/window.lua
@@ -53,10 +53,17 @@ function M.get_window_context(multi_windows)
   -- Generate contexts of windows
   local cur_hwin = vim.api.nvim_get_current_win()
   local cur_hbuf = vim.api.nvim_win_get_buf(cur_hwin)
+  local cur_col
+
+  if vim.api.nvim_get_current_line() == '' then
+    cur_col = 0
+  else
+    cur_col = vim.fn.charcol('.')
+  end
 
   all_ctxs[#all_ctxs + 1] = {
     hbuf = cur_hbuf,
-    contexts = { window_context(cur_hwin, {vim.fn.line('.'), vim.fn.charcol('.')} ) },
+    contexts = { window_context(cur_hwin, {vim.fn.line('.'), cur_col} ) },
   }
 
   if not multi_windows then


### PR DESCRIPTION
Fix regression of phaazon/hop.nvim#267 caused by pull#315

- opts.col passed to nvim_buf_set_extmark() expects it to be 0-indexed.  phaazon/hop.nvim#315 causes an empty line to retun 1 for cursor's column. This PR checks if the current line is empty and sets the correct column in 'contexts' that'll be used later in nvim_buf_set_extmark() in set_unmatched_lines()