### PR TITLE
Fix command line window error

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -298,7 +298,9 @@ function M.move_cursor_to(w, line, column, hint_offset, direction)
 
   -- update the jump list
   vim.cmd("normal! m'")
-  vim.api.nvim_set_current_win(w)
+  if vim.fn.bufname() ~= "[Command Line]" then
+      vim.api.nvim_set_current_win(w)
+  end
   vim.api.nvim_win_set_cursor(w, { line, column })
 end
 

--- a/lua/hop/window.lua
+++ b/lua/hop/window.lua
@@ -4,7 +4,9 @@ local M = {}
 
 local function window_context(win_handle, cursor_pos)
   -- get a bunch of information about the window and the cursor
-  vim.api.nvim_set_current_win(win_handle)
+  if vim.fn.bufname() ~= "[Command Line]" then
+      vim.api.nvim_set_current_win(win_handle)
+  end
   local win_info = vim.fn.getwininfo(win_handle)[1]
   local win_view = vim.fn.winsaveview()
   local top_line = win_info.topline - 1
@@ -90,7 +92,9 @@ function M.get_window_context(multi_windows)
   end
 
   -- Move cursor back to current window
-  vim.api.nvim_set_current_win(cur_hwin)
+  if vim.fn.bufname() ~= "[Command Line]" then
+      vim.api.nvim_set_current_win(cur_hwin)
+  end
 
   return all_ctxs
 end


### PR DESCRIPTION
Fixes #333 by checking whether we are inside the command line window before applying the `nvim_set_current_win` function. If we are inside the command line window we already know we have it focused (the command line window is focused  [automatically](http://neovim.io/doc/user/cmdline.html#cmdline-window)) so `nvim_set_current_win` is redundant.
Thus, leaving out the `nvim_set_current_win` in the command line window case fixes the bug.
