### PR TITLE
health: Update from deprecated health api

### DIFF
--- a/lua/hop/health.lua
+++ b/lua/hop/health.lua
@@ -7,14 +7,14 @@ local hop = require'hop'
 function M.check()
   local health = vim.health or require'health'
 
-  health.report_start('Ensuring keys are unique')
+  health.start('Ensuring keys are unique')
   local existing_keys = {}
   local had_errors = false
   for i = 0, #hop.opts.keys do
     local key = hop.opts.keys:sub(i, i)
 
     if existing_keys[key] then
-      health.report_error(string.format('key %s appears more than once in opts.keys', key))
+      health.error(string.format('key %s appears more than once in opts.keys', key))
       had_errors = true
     else
       existing_keys[key] = true
@@ -22,14 +22,14 @@ function M.check()
   end
 
   if not had_errors then
-    health.report_ok('Keys are unique')
+    health.ok('Keys are unique')
   end
 
-  health.report_start('Checking for deprecated features')
+  health.start('Checking for deprecated features')
   had_errors = false
 
   if not had_errors then
-    health.report_ok('All good')
+    health.ok('All good')
   end
 end
 


### PR DESCRIPTION
From the help:

```
  - *health#report_error* *vim.health.report_error()*     Use |vim.health.error()| instead.
  - *health#report_info* *vim.health.report_info()*       Use |vim.health.info()| instead.
  - *health#report_ok* *vim.health.report_ok()*           Use |vim.health.ok()| instead.
  - *health#report_start* *vim.health.report_start()*     Use |vim.health.start()| instead.
  - *health#report_warn* *vim.health.report_warn()*       Use |vim.health.warn()| instead.
```