### PR TITLE
null character line error fix

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -164,6 +164,10 @@ local function add_virt_cur(ns)
   local virt_col = cur_info[5] - 1
   local cur_line = vim.api.nvim_get_current_line()
 
+  if vim.fn.type(cur_line) == vim.v.t_blob then
+    return {}
+  end
+
   -- toggle cursorline off if currently set
   local cursorline_info = vim.api.nvim_win_get_option(vim.api.nvim_get_current_win(), 'cursorline')
   if cursorline_info == true then

--- a/lua/hop/jump_target.lua
+++ b/lua/hop/jump_target.lua
@@ -60,6 +60,11 @@ local function mark_jump_targets_line(buf_handle, win_handle, regex, line_contex
   local jump_targets = {}
   local end_index = nil
 
+
+  if vim.fn.type(line_context.line) == vim.v.t_blob then
+    return {}
+  end
+
   if win_width ~= nil then
     end_index = col_offset + win_width
   else


### PR DESCRIPTION
If a line contains a null character (`^@`), it breaks the following functions:

```
vim.fn.strdisplaywidth(line_context.line)
```
```
end_col = vim.fn.byteidx(cur_line, vim.fn.charidx(cur_line, cur_col) + 1),
```
added an early return if a line contains blob